### PR TITLE
Always send a referer but spoof it first

### DIFF
--- a/user.js
+++ b/user.js
@@ -38,8 +38,10 @@
 // https://www.mozilla.org/projects/security/pki/nss/nss-3.11/nss-3.11-algorithms.html
 
 // http://kb.mozillazine.org/Network.http.sendRefererHeader#0
-// Never send the Referer header or set document.referrer.
-user_pref("network.http.sendRefererHeader",	0);
+// https://bugzilla.mozilla.org/show_bug.cgi?id=822869
+// Send a referer header with the target URI as the source
+user_pref("network.http.sendRefererHeader",	1);
+user_pref("network.http.referer.spoofSource",	1);
 
 // disable HTML frames
 // WARNING: might make your life difficult!


### PR DESCRIPTION
Blocking referers breaks some sites, but these sites will happily accept a
spoofed one.