### PR TITLE
logjam related disabling of two more DH ciphers

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,6 @@ Here's the list with this config:
 	    Cipher Suite: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 (0xc02f)
 	    Cipher Suite: TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA (0xc00a)
 	    Cipher Suite: TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA (0xc014)
-	    Cipher Suite: TLS_DHE_RSA_WITH_AES_256_CBC_SHA (0x0039)
-	    Cipher Suite: TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA (0x0088)
 	    Cipher Suite: TLS_RSA_WITH_AES_128_CBC_SHA (0x002f)
 	    Cipher Suite: TLS_RSA_WITH_AES_256_CBC_SHA (0x0035)
 

--- a/user.js
+++ b/user.js
@@ -487,10 +487,12 @@ user_pref("security.ssl3.ecdhe_rsa_aes_128_gcm_sha256",		true);
 /* ciphers with DHE and > 128bits
  * des-ede3 = 168 bits
  */
-user_pref("security.ssl3.dhe_rsa_camellia_256_sha",	true);
 //user_pref("security.ssl3.dhe_dss_camellia_256_sha",	true);
-user_pref("security.ssl3.dhe_rsa_aes_256_sha",		true);
 //user_pref("security.ssl3.dhe_dss_aes_256_sha",		true);
+
+// susceptible to the logjam attack – https://weakdh.org/
+user_pref("security.ssl3.dhe_rsa_camellia_256_sha",	false);
+user_pref("security.ssl3.dhe_rsa_aes_256_sha",		false);
 
 // ciphers with DSA (max 1024 bits)
 user_pref("security.ssl3.dhe_dss_aes_128_sha",		false);


### PR DESCRIPTION
See "The logjam attack" – https://weakdh.org/. The two ciphers are enabled at the moment in user.js but are susceptible to the logjam attack and thus should be disabled as well.