### PR TITLE
NoScript NSA will not work anymore after FF42+

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ See also:
 
 #### Add-ons for mobile platforms
 
-* [NoScript Anywhere](https://noscript.net/nsa/)
+* [NoScript Anywhere](https://noscript.net/nsa/) - will not work anymore after FireFox 42+, [due addons and signature changes](https://github.com/pyllyukko/user.js#issuecomment-130116288)
 * [uBlock](https://addons.mozilla.org/en-US/android/addon/ublock-origin/)
 * [HTTPS Everywhere](https://www.eff.org/https-everywhere)
 


### PR DESCRIPTION
added a warning about coming changes, for more details take a look [here](https://github.com/pyllyukko/user.js#issuecomment-130116288)

The addon itself is okay, but Mozilla seems to massive improve the entire add-ons stuff, after FF42 this can't be reversed with any about:config tweak (in the name of security) other add-ons are maybe also affected by this e.g. HTTPSE since this isn't in the store and also use old API's that getting removed, we will see if there will be an update or not, in the future HTTPSE will be obsolete anyway since this is already checked with FF 41+.

Only ESR versions are not affected by this (atm). 