### PR TITLE
Bigger update to fit with HTTPSE and NoScript

### DIFF
--- a/user.js
+++ b/user.js
@@ -619,3 +619,62 @@ user_pref("security.ssl3.dhe_dss_camellia_256_sha",		false);
 // Fallbacks due compatibility reasons
 user_pref("security.ssl3.rsa_aes_256_sha",		true);
 user_pref("security.ssl3.rsa_aes_128_sha",		true);
+
+/******************************************************************************
+ * HTTPS Everywhere Preferences:                                              *
+ * Harden some stuff that isn't visible by default                            *
+ ******************************************************************************/
+user_pref("extensions.https_everywhere._observatory.popup_shown", true);
+user_pref("extensions.https_everywhere.toolbar_hint_shown", true);
+
+
+/******************************************************************************
+ * NoScript:                                                                  *
+ * A compromise between security and usability                                *
+ ******************************************************************************/
+
+
+pref("capability.policy.maonoscript.javascript.enabled", "allAccess");
+pref("capability.policy.maonoscript.sites", "about: chrome: resource:");
+pref("noscript.ABE.enabled", true);
+pref("noscript.ABE.notify", true);
+pref("noscript.ABE.wanIpAsLocal", true);
+pref("noscript.confirmUnblock", false);
+pref("noscript.contentBlocker", true);
+pref("noscript.default", "about: chrome: resource:");
+pref("noscript.firstRunRedirection", false);
+pref("noscript.global", true);
+pref("noscript.opacizeObject", 3);
+pref("noscript.forbidWebGL", true);
+//can be handled better by uBlock/uMatrix
+pref("noscript.forbidFonts", false);
+pref("noscript.options.tabSelectedIndexes", "5,0,0");
+// automatically use secure cookies on every https page
+pref("noscript.secureCookies", true);
+pref("noscript.showAllowPage", true);
+pref("noscript.showBaseDomain", false);
+pref("noscript.showDistrust", false);
+pref("noscript.showRecentlyBlocked", false);
+pref("noscript.showTemp", true);
+pref("noscript.showTempToPerm", false);
+pref("noscript.showUntrusted", false);
+pref("noscript.STS.enabled", true);
+pref("noscript.forbidMedia", false);
+pref("noscript.allowWhitelistUpdates", false);
+// Now handled by plugins.click_to_play
+pref("noscript.forbidFlash", false);
+pref("noscript.forbidSilverlight", false);
+pref("noscript.forbidJava", false);
+pref("noscript.forbidPlugins", false);
+// Usability tweaks
+pref("noscript.showPermanent", false);
+pref("noscript.showTempAllowPage", true);
+pref("noscript.showRevokeTemp", true);
+pref("noscript.notify", false);
+pref("noscript.autoReload", true);
+pref("noscript.autoReload.allTabs", false);
+pref("noscript.cascadePermissions", true);
+pref("noscript.restrictSubdocScripting", true);
+pref("noscript.showVolatilePrivatePermissionsToggle", false);
+pref("noscript.volatilePrivatePermissions", true);
+pref("noscript.clearClick", 1);


### PR DESCRIPTION
Since we're recommend (and using) NoScript and HTTPS Everywhere, we can just harden some more stuff from the beginning. 

HTTPS Everywhere:
* Enable all popup messages to notify on observatory problems/changes/news
* Enable the toolbar hint (not annoying)

NoScript:
The settings are to fit with Firefox, so e.g. we doesn't want to allow webgl (except on whitelistening pages the user sets - if not set also apply these restrictions to whitelist sites too -> must be manually set because it's up to the user).

* Enable ABE (don't do this on Tor)
* Enable STS (don't do this on Tor)
* Don't allow the cliuck-to-play stuff, it's depcreated and only for older FF versions (or maybe ESR variants of it) 
* Only allow the current tab on change (not all opened tabs)
* Cascade the menu, it's a visual tweak 
* Show some other visual options to not get useless things displayed and reveal only stuff that is important, uBlock or uMatrix already do a better finer job for this 
* Changed the default policy to harden possible security related 'leaks' 
* Media is enabled since this breaks so many pages (due .js, HTML5) [use Random Agent Spoofer or uMarix for this]