### PR TITLE
added JavaScript exploit protection (optional)

### DIFF
--- a/user.js
+++ b/user.js
@@ -8,6 +8,13 @@
  *                                                                            *
  ******************************************************************************/
 
+// Protection against Javascript exploits to block eval() 
+// See: https://hackademix.net/2011/09/29/script-surrogates-quick-reference/
+//noscript.surrogate.noeval.replacement,		window.eval = null;document.eval=null;
+//noscript.surrogate.noeval.sources,		@^http://[a-z]+[^/]+\.[a-z]+(?:/|$);
+//noscript.surrogate.noeval.exceptions;
+
+
 // disable Location-Aware Browsing
 // http://www.mozilla.org/en-US/firefox/geolocation/
 user_pref("geo.enabled",		false);


### PR DESCRIPTION
Optional protection against eval() to execute data like it was code.

Why optional?
it possible breaks some legit site (normal sites should not use eval but all is possible and it must be exluded manually)