### PR TITLE
Remove unnecessary pref and update tracking protection link (fix #62)

### DIFF
--- a/user.js
+++ b/user.js
@@ -186,11 +186,9 @@ user_pref("toolkit.telemetry.enabled",		false);
 // https://gecko.readthedocs.org/en/latest/toolkit/components/telemetry/telemetry/preferences.html
 user_pref("toolkit.telemetry.unified",		false);
 
-// https://wiki.mozilla.org/Polaris#Tracking_protection
+// https://wiki.mozilla.org/Security/Tracking_protection
 // https://support.mozilla.org/en-US/kb/tracking-protection-firefox
-// TODO: are these two the same?
 user_pref("privacy.trackingprotection.enabled",		true);
-user_pref("browser.polaris.enabled",		true);
 
 // Disable the built-in PDF viewer (CVE-2015-2743)
 // https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-2743


### PR DESCRIPTION
`browser.polaris.enabled` isn't needed for tracking protection and can be removed.