### PR TITLE
Disabled SSL cert. error reporting

### DIFF
--- a/user.js
+++ b/user.js
@@ -484,6 +484,10 @@ user_pref("security.ask_for_password",		0);
  *                                                                            *
  ******************************************************************************/
 
+// Disable SSL Certification error reporting, since we use HTTPSE we not need both
+//See: https://gecko.readthedocs.org/en/latest/browser/base/sslerrorreport/preferences.html
+//user_pref("security.ssl.errorReporting.enabled,		false);
+
 // https://blog.mozilla.org/security/2012/11/01/preloading-hsts/
 // https://wiki.mozilla.org/Privacy/Features/HSTS_Preload_List
 user_pref("network.stricttransportsecurity.preloadlist",		true);


### PR DESCRIPTION
Disabled the SSL error reporting stuff, better use HTTPSE 
https://gecko.readthedocs.org/en/latest/browser/base/sslerrorreport/preferences.html

Optional because you maybe not use HTTPSE Observatory or your AV doesn't comes with it's own reporting feature (or you simply use no AV).