### PR TITLE
Make private browsing optional

### DIFF
--- a/user.js
+++ b/user.js
@@ -359,8 +359,8 @@ user_pref("browser.cache.offline.enable",		false);
 // Always use private browsing
 // https://support.mozilla.org/en-US/kb/Private-Browsing
 // https://wiki.mozilla.org/PrivateBrowsing
-user_pref("browser.privatebrowsing.autostart",		true);
-user_pref("extensions.ghostery.privateBrowsing",		true);
+//user_pref("browser.privatebrowsing.autostart",		true);
+//user_pref("extensions.ghostery.privateBrowsing",		true);
 
 // Clear history when Firefox closes
 // https://support.mozilla.org/en-US/kb/Clear%20Recent%20History#w_how-do-i-make-firefox-clear-my-history-automatically


### PR DESCRIPTION
Removed private browsing and mark it as optional since there is no benefit except to break addons

The test example pages doesn't care about private browsing mode or not, Mozilla not enabled by default for several reasons so I think without any real benefit we are already safe to go with NoScript + uBlock + some Options which are already adopted to FF (e.g. clean all Cookies at shutdown and such).