### PR TITLE
No need to completely disable WebRTC anymore

### DIFF
--- a/user.js
+++ b/user.js
@@ -17,10 +17,12 @@ user_pref("geo.enabled",		false);
 // you can also see this with Panopticlick's "DOM localStorage"
 //user_pref("dom.storage.enabled",		false);
 
-// Don't reveal internal IPs
-// http://net.ipcalf.com/
+// Don't reveal your internal IP
+// Check the settings with: http://net.ipcalf.com/
 // https://wiki.mozilla.org/Media/WebRTC/Privacy
 user_pref("media-peerconnection.ice.default_address_only",		true);
+//user_pref("media.peerconnection.enabled",		false);
+
 // getUserMedia
 // https://wiki.mozilla.org/Media/getUserMedia
 // https://developer.mozilla.org/en-US/docs/Web/API/Navigator

--- a/user.js
+++ b/user.js
@@ -19,7 +19,8 @@ user_pref("geo.enabled",		false);
 
 // Don't reveal internal IPs
 // http://net.ipcalf.com/
-user_pref("media.peerconnection.enabled",		false);
+// https://wiki.mozilla.org/Media/WebRTC/Privacy
+user_pref("media-peerconnection.ice.default_address_only",		true);
 // getUserMedia
 // https://wiki.mozilla.org/Media/getUserMedia
 // https://developer.mozilla.org/en-US/docs/Web/API/Navigator

--- a/user.js
+++ b/user.js
@@ -21,7 +21,7 @@ user_pref("geo.enabled",		false);
 // Check the settings with: http://net.ipcalf.com/
 // https://wiki.mozilla.org/Media/WebRTC/Privacy
 user_pref("media-peerconnection.ice.default_address_only",		true);
-//user_pref("media.peerconnection.enabled",		false);
+user_pref("media.peerconnection.enabled",		false);
 
 // getUserMedia
 // https://wiki.mozilla.org/Media/getUserMedia


### PR DESCRIPTION
No need to disable WebRTC anymore, because WebRTC is not overall bad and some pages will be not working anymore if you disabled it competently. Now we got an option to use it without leaking the IP, because now only the IP will be used that is visible to the server.