### PR TITLE
Firefox Addon Detector added

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ Online tests
 * [RC4 fallback test](https://rc4.io/)
 * [Battery API](https://robnyman.github.io/battery/)
 * [AmIUnique](https://amiunique.org/) ([Source](https://github.com/DIVERSIFY-project/amiunique))
+* [Firefox Addon Detector](https://thehackerblog.com/addon_scanner/index.html) (unofficial)
 
 
 ### HTML5test


### PR DESCRIPTION
Added an online test which detects (or in our case not detect) addons. It's unofficial one and needs Javascript enabled + Session cookies. Remember that if you use NoScript and uBlock to 'unlock' (allow it/whitelist) to get some results. If it shoes something this means you have a leak which allows external pages to detect your addons, but we have 'normally' fixed that with the addon meta-data blocking thing.