### PR TITLE
Kill SHA1 certificates

### DIFF
--- a/user.js
+++ b/user.js
@@ -555,6 +555,7 @@ user_pref("security.enable_ssl3",		false);
 // https://wiki.mozilla.org/SecurityEngineering/Public_Key_Pinning#How_to_use_pinning
 // "2. Strict. Pinning is always enforced."
 user_pref("security.cert_pinning.enforcement_level",		2);
+//user_pref("security.pki.sha1_enforcement_level", 1);
 
 // https://wiki.mozilla.org/Security:Renegotiation#security.ssl.treat_unsafe_negotiation_as_broken
 // see also CVE-2009-3555

--- a/user.js
+++ b/user.js
@@ -555,6 +555,9 @@ user_pref("security.enable_ssl3",		false);
 // https://wiki.mozilla.org/SecurityEngineering/Public_Key_Pinning#How_to_use_pinning
 // "2. Strict. Pinning is always enforced."
 user_pref("security.cert_pinning.enforcement_level",		2);
+
+// Kill SHA1 certificates
+// https://bugzilla.mozilla.org/show_bug.cgi?id=942515#c32
 //user_pref("security.pki.sha1_enforcement_level", 1);
 
 // https://wiki.mozilla.org/Security:Renegotiation#security.ssl.treat_unsafe_negotiation_as_broken
@@ -575,11 +578,6 @@ user_pref("security.ssl.treat_unsafe_negotiation_as_broken",		true);
 //
 // you can test this at https://pinningtest.appspot.com/
 user_pref("security.ssl.errorReporting.automatic",		false);
-
-// Kill SHA1 certificates
-// https://bugzilla.mozilla.org/show_bug.cgi?id=942515#c32
-// http://www.scmagazine.com/mozilla-pulls-back-on-rejecting-sha-1-certs-outright/article/463913/
-//user_pref("security.pki.sha1_enforcement_level", 1);
 
 /******************************************************************************
  * CIPHERS                                                                    *

--- a/user.js
+++ b/user.js
@@ -575,6 +575,11 @@ user_pref("security.ssl.treat_unsafe_negotiation_as_broken",		true);
 // you can test this at https://pinningtest.appspot.com/
 user_pref("security.ssl.errorReporting.automatic",		false);
 
+// Kill SHA1 certificates
+// https://bugzilla.mozilla.org/show_bug.cgi?id=942515#c32
+// http://www.scmagazine.com/mozilla-pulls-back-on-rejecting-sha-1-certs-outright/article/463913/
+//user_pref("security.pki.sha1_enforcement_level", 1);
+
 /******************************************************************************
  * CIPHERS                                                                    *
  *                                                                            *


### PR DESCRIPTION
Firefox now allows SHA1 certificates issued after Jan 1 2016 again because HTTPS scanning/MitM products [are outdated](https://blog.mozilla.org/security/2016/01/06/man-in-the-middle-interfering-with-increased-security/).

```
You can influence Firefox's policy on this by setting "security.pki.sha1_enforcement_level":
0 = allow SHA-1
1 = forbid SHA-1
2 = allow SHA-1 only if not before < 2016-01-01
```