### PR TITLE
Disable Hardware Acceleration to avoid fingerprints

### DIFF
--- a/user.js
+++ b/user.js
@@ -2,6 +2,17 @@
  * user.js                                                                    *
  * https://github.com/pyllyukko/user.js                                       *
  ******************************************************************************/
+ 
+ /******************************************************************************
+ * Avoid hardware based fingerprintings                                       *
+ * Canvas/Font's/Plugins                                                                           *
+ ******************************************************************************/
+// https://wiki.mozilla.org/Platform/GFX/HardwareAcceleration
+// https://www.macromedia.com/support/documentation/en/flashplayer/help/help01.html
+//https://github.com/dillbyrne/random-agent-spoofer/issues/74
+ user_pref("gfx.direct2d.disabled",		true);
+ user_pref("layers.acceleration.disabled",		true);
+ 
 
 /******************************************************************************
  * HTML5 / APIs / DOM                                                         *


### PR DESCRIPTION
* Not needed since FFmpeg 3.0 is here, which allows hardware acc. anyway even if you disable it directly with about:config (just use right click to enable it if you want it) of course the page must support this but I'm sure YouTube/Vimeo/MetaCafe and others will change this asap ...
* This needs to be disabled also (if in use) in Adobe Flash/Macromedia to avoid Canvas fingerprinting for font's
* Hardware Acc. doesn't perform well on some systems, which should better controlled by driver settings to override it (if you want)


Research:
* http://www.phoronix.com/scan.php?page=news_item&px=FFmpeg-3.0-Released
* https://hacks.mozilla.org/2010/09/hardware-acceleration/
* https://www.google.com/patents/US20120215896 (just an example for device identification on networks)
* .... several already mentioned Tor papers about this