### PR TITLE
add network.dns.blockDotOnion option

### DIFF
--- a/user.js
+++ b/user.js
@@ -309,6 +309,9 @@ user_pref("browser.search.geoip.url",		"");
 user_pref("network.dns.disablePrefetch",		true);
 user_pref("network.dns.disablePrefetchFromHTTPS",		true);
 
+// https://bugzilla.mozilla.org/show_bug.cgi?id=1228457
+user_pref("network.dns.blockDotOnion",      true);
+
 // https://wiki.mozilla.org/Privacy/Reviews/Necko
 user_pref("network.predictor.enabled",		false);
 // https://wiki.mozilla.org/Privacy/Reviews/Necko#Principle:_Real_Choice


### PR DESCRIPTION
Added in firefox 45

https://www.mozilla.org/en-US/firefox/45.0/releasenotes/ 

Added it to user.js since it's a policy to hardcode the proper values even if the default (which is true in ff) is reasonable already.