### PR TITLE
Disable dom.netinfo.enabled - Network info fingerprinting

### DIFF
--- a/user.js
+++ b/user.js
@@ -28,6 +28,13 @@ user_pref("geo.enabled",		false);
 // you can also see this with Panopticlick's "DOM localStorage"
 //user_pref("dom.storage.enabled",		false);
 
+// Whether JS can get information about the network/browser connection
+// Network Information API provides general information about the system's connection type (WiFi, cellar, etc.)
+// https://developer.mozilla.org/en-US/docs/Web/API/Network_Information_API
+// https://wicg.github.io/netinfo/
+// https://bugzilla.mozilla.org/show_bug.cgi?id=960426
+//user_pref("dom.netinfo.enabled"",		false);
+
 // Don't reveal your internal IP
 // Check the settings with: http://net.ipcalf.com/
 // https://wiki.mozilla.org/Media/WebRTC/Privacy


### PR DESCRIPTION
Merge suggestion from #160.