### PR TITLE
Replace "Smart HTTPS" with "HTTPS by default"

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ Here is a list of the most essential security and privacy enhancing add-ons that
 
 * [Certificate Patrol][4]
   * I recommend setting the 'Store certificates even when in [Private Browsing][8] Mode' to get full benefit out of certpatrol, even though it stores information about the sites you visit
-* [HTTPS Everywhere](https://www.eff.org/https-everywhere) (or [Smart HTTPS](https://addons.mozilla.org/firefox/addon/smart-https/))
+* [HTTPS Everywhere](https://www.eff.org/https-everywhere) and [HTTPS by default](https://addons.mozilla.org/firefox/addon/https-by-default/)
 * [NoScript](http://noscript.net/)
 * [DuckDuckGo Plus](https://addons.mozilla.org/firefox/addon/duckduckgo-for-firefox/) (instead of Google)
 * [No Resource URI Leak](https://addons.mozilla.org/firefox/addon/no-resource-uri-leak/) (see [#163](https://github.com/pyllyukko/user.js/issues/163))

--- a/user.js
+++ b/user.js
@@ -135,6 +135,10 @@ user_pref("clipboard.autocopy",					false);
 // http://kb.mozillazine.org/Keyword.enabled#Caveats
 user_pref("keyword.enabled",					false);
 
+// Don't trim HTTP off of URLs in the address bar.
+// https://bugzilla.mozilla.org/show_bug.cgi?id=665580
+user_pref("browser.urlbar.trimURLs",				false);
+
 // Don't try to guess where i'm trying to go!!! e.g.: "http://foo" -> "http://(prefix)foo(suffix)"
 // http://www-archive.mozilla.org/docs/end-user/domain-guessing.html
 user_pref("browser.fixup.alternate.enabled",			false);


### PR DESCRIPTION
[Smart HTTPS](https://addons.mozilla.org/firefox/addon/smart-https) seems to break a few sites in non-obvious ways and its defaults are not great. [HTTPS by default](https://addons.mozilla.org/firefox/addon/https-by-default) has none of these problems and just does one thing well: it changes the default scheme when typing scheme-less URLs in the address bar.

Also add the trimURLs setting to user.js since it's [recommended by the author of "HTTPS by default"](https://github.com/Rob--W/https-by-default#firefox) and it will probably appeal to the user.js crowd too.