### PR TITLE
Bump max TLS version

### DIFF
--- a/user.js
+++ b/user.js
@@ -603,7 +603,7 @@ user_pref("security.ssl.disable_session_identifiers",		true);
 // 1 = TLS 1.0 is the minimum required / maximum supported encryption protocol. (This is the current default for the maximum supported version.)
 // 2 = TLS 1.1 is the minimum required / maximum supported encryption protocol.
 user_pref("security.tls.version.min",				1);
-user_pref("security.tls.version.max",				3);
+user_pref("security.tls.version.max",				4);
 
 // pinning
 // https://wiki.mozilla.org/SecurityEngineering/Public_Key_Pinning#How_to_use_pinning

--- a/user.js
+++ b/user.js
@@ -606,7 +606,7 @@ user_pref("security.tls.version.min",				1);
 user_pref("security.tls.version.max",				4);
 
 // TLS version fallback
-user_pref("security.tls.version.fallback-limit", 3);
+user_pref("security.tls.version.fallback-limit",		3);
 
 // pinning
 // https://wiki.mozilla.org/SecurityEngineering/Public_Key_Pinning#How_to_use_pinning

--- a/user.js
+++ b/user.js
@@ -605,6 +605,9 @@ user_pref("security.ssl.disable_session_identifiers",		true);
 user_pref("security.tls.version.min",				1);
 user_pref("security.tls.version.max",				4);
 
+// TLS version fallback
+user_pref("security.tls.version.fallback-limit", 3);
+
 // pinning
 // https://wiki.mozilla.org/SecurityEngineering/Public_Key_Pinning#How_to_use_pinning
 // "2. Strict. Pinning is always enforced."


### PR DESCRIPTION
`security.tls.version.max=4` is compatible with Firefox versions 51.0.1 and above.