### PR TITLE
README: refactor addons section; other fixes; fix GEOLOCATION/QUIET FOX sections of #208

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ before_script:
 script:
   - acorn user.js
   - bash -n cas.sh
+  - make tests
 notifications:
   irc:
     channels:

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,16 @@
+pyllyukko <pyllyukko@maimed.org>
+nodiscc <nodiscc@gmail.com>
+CHEF-KOCH <CHEF-KOCH@users.noreply.github.com>
+Francois Marier <francois@mozilla.com>
+CHEF-KOCH <Nvinside@gmail.com>
+Francois Marier <francois@debian.org>
+Alex Hirsch <w4rh4wk@bluephoenix.at>
+DrunkenSasquatch <j.hamshere91@gmail.com>
+Frank LENORMAND <lenormf@gmail.com>
+Sebastian Schmidt <publicarray@icloud.com>
+Steffen Gransow <graste@mivesto.de>
+devmapper0 <devmapper0@users.noreply.github.com>
+Mehmet Atif Ergun <mehmetaergun@users.noreply.github.com>
+mengele-chan <mengele-chan@yandex.ru>
+uberspot <onexemailx@gmail.com>
+zummuz <zummuz@users.noreply.github.com>

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,56 @@
+all: whatdoesitdo tests authors
+
 whatdoesitdo:
+	@# generate the README "What does it do?" section
 	@./gen-readme.sh
+
+# To decrease tests verbosity, comment out unneeded targets
+tests: downloadffprefs checknotcovered checkdeprecated stats cleanup
+
+
+downloadffprefs:
+	@# download and sort all known preferences files from Firefox (mozilla-central) source
+	@# specify wanted Firefox version/revision below (eg. "tip", "FIREFOX_AURORA_45_BASE", "9577ddeaafd85554c2a855f385a87472a089d5c0"). See https://hg.mozilla.org/mozilla-central/tags
+	@SOURCEVERSION="tip"; \
+	FIREFOX_SOURCE_PREFS=" \
+	https://hg.mozilla.org/mozilla-central/raw-file/$$SOURCEVERSION/toolkit/components/telemetry/datareporting-prefs.js \
+	https://hg.mozilla.org/mozilla-central/raw-file/$$SOURCEVERSION/toolkit/components/telemetry/healthreport-prefs.js \
+	https://hg.mozilla.org/mozilla-central/raw-file/$$SOURCEVERSION/security/manager/ssl/security-prefs.js \
+	https://hg.mozilla.org/mozilla-central/raw-file/$$SOURCEVERSION/modules/libpref/init/all.js \
+	https://hg.mozilla.org/mozilla-central/raw-file/$$SOURCEVERSION/testing/profiles/prefs_general.js \
+	https://hg.mozilla.org/mozilla-central/raw-file/$$SOURCEVERSION/layout/tools/reftest/reftest-preferences.js \
+	https://hg.mozilla.org/mozilla-central/raw-file/$$SOURCEVERSION/js/src/tests/user.js"; \
+	for SOURCEFILE in $$FIREFOX_SOURCE_PREFS; do wget "$$SOURCEFILE" -O - ; done | egrep "(^pref|^user_pref)" | sort --unique >| sourceprefs.js
+
+######################
+
+checknotcovered:
+	@# check for preferences present in firefox source but not covered by user.js
+	@# configure ignored preferences in ignore.list
+	@SOURCE_PREFS=$$(egrep '(^pref|^user_pref)' sourceprefs.js | awk -F'"' '{print $$2}'); \
+	for SOURCE_PREF in $$SOURCE_PREFS; do \
+	grep "\"$$SOURCE_PREF\"" user.js ignore.list >/dev/null || echo "Not covered by user.js : $$SOURCE_PREF"; \
+	done | sort --unique
+
+checkdeprecated:
+	@# check for preferences in hardened user.js that are no longer present in firefox source
+	@HARDENED_PREFS=$$(egrep "^user_pref" user.js | cut -d'"' -f2); \
+	for HARDENED_PREF in $$HARDENED_PREFS; do \
+	grep "\"$$HARDENED_PREF\"" sourceprefs.js  >/dev/null || echo "Deprecated : $$HARDENED_PREF"; \
+	done | sort --unique
+
+stats:
+	@# count preferences number, various stats
+	@echo "$$(egrep "^user_pref" user.js | wc -l | cut -f1) preferences in user.js"
+	@echo "$$(wc -l sourceprefs.js | cut -d" " -f1) preferences in Firefox source"
+
+cleanup:
+	@# remove temporary files
+	@# please comment this out when not needed, to minimize load on Mozilla servers
+	@rm sourceprefs.js
+
+authors:
+	@# generate an AUTHORS file, ordered by number of commits
+	@# TODO: add a .mailmap file to deduplicate authors with multiple email addresses
+	@# to add extra authors/credits, git commit --allow-empty --author="A U Thor <author@example.com>"
+	@git shortlog -sne | cut -f1 --complement >| AUTHORS

--- a/README.md
+++ b/README.md
@@ -405,8 +405,10 @@ No. Please read [Known problems and limitations](#known-problems-and-limitations
 
 > Why are obsolete/deprecated entries included in the user.js file?
 
-In case you want to use an older Firefox version (e.g. [ESR](https://www.mozilla.org/en-US/firefox/organizations/),
-or for test reasons) and normally it doesn't hurt your browser if there are deprecated about:config preferences present.
+This project is aimed at Firefox versions between the current [ESR](https://www.mozilla.org/en-US/firefox/organizations/)
+and the latest Firefox release. We will wait for widespread deployment of the current ESR
+(eg. adoption in major Linux distributions) before removing deprecated/obsolete preferences.
+Presence of deprecated entries causes no known problems.
 
 > Installing the user.js file breaks xyz plugin/addon/extension, how can I fix it?
 

--- a/README.md
+++ b/README.md
@@ -158,8 +158,12 @@ HTML5 / [APIs](https://wiki.mozilla.org/WebAPI) / [DOM](https://en.wikipedia.org
 Settings that do not belong to other sections or are user specific preferences.
 * Disable face detection
 * Disable GeoIP lookup on your address to set default search engine region [ [1](https://trac.torproject.org/projects/tor/ticket/16254) [2](https://support.mozilla.org/en-US/kb/how-stop-firefox-making-automatic-connections#w_geolocation-for-default-search-engine) ]
-* Set locale to en-US (if you are using localized version of FF)
+* Set Accept-Language HTTP header to en-US regardless of Firefox localization [ [1](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language) ]
+* Set Firefox locale to en-US
+* Don't use OS values to determine locale, force using Firefox locale setting
+* Don't use Mozilla-provided location-specific search engines
 * Do not automatically send selection to clipboard on some Linux platforms [ [1](http://kb.mozillazine.org/Clipboard.autocopy) ]
+* Prevent leaking application locale/date format using JavaScript [ [1](https://bugzilla.mozilla.org/show_bug.cgi?id=867501) [2](https://hg.mozilla.org/mozilla-central/rev/52d635f2b33d) ]
 * Do not submit invalid URIs entered in the address bar to the default search engine [ [1](http://kb.mozillazine.org/Keyword.enabled) ]
 * Don't trim HTTP off of URLs in the address bar. [ [1](https://bugzilla.mozilla.org/show_bug.cgi?id=665580) ]
 * Don't try to guess domain names when entering an invalid domain name in URL bar [ [1](http://www-archive.mozilla.org/docs/end-user/domain-guessing.html) ]
@@ -181,8 +185,11 @@ Harden preferences related to external plugins
 * Ensure you have a security delay when installing add-ons (milliseconds) [ [1](http://kb.mozillazine.org/Disable_extension_install_delay_-_Firefox) [2](http://www.squarefree.com/2004/07/01/race-conditions-in-security-dialogs/) ]
 * Require signatures [ [1](https://wiki.mozilla.org/Addons/Extension_Signing) ]
 * Opt-out of add-on metadata updates [ [1](https://blog.mozilla.org/addons/how-to-opt-out-of-add-on-metadata-updates/) ]
-* Flash plugin state - never activate [ [1](http://kb.mozillazine.org/Flash_plugin) ]
+* Opt-out of themes (Persona) updates [ [1](https://support.mozilla.org/t5/Firefox/how-do-I-prevent-autoamtic-updates-in-a-50-user-environment/td-p/144287) ]
+* Flash Player plugin state - never activate [ [1](http://kb.mozillazine.org/Flash_plugin) ]
 * Java plugin state - never activate
+* Disable sending Flash Player crash reports
+* When Flash crash reports are enabled, don't send the visited URL in the crash report
 * Disable Gnome Shell Integration
 * Enable plugins click-to-play [ [1](https://wiki.mozilla.org/Firefox/Click_To_Play) [2](https://blog.mozilla.org/security/2012/10/11/click-to-play-plugins-blocklist-style/) ]
 * Updates addons automatically [ [1](https://blog.mozilla.org/addons/how-to-turn-off-add-on-updates/) ]
@@ -194,7 +201,12 @@ Harden preferences related to external plugins
 Disable Firefox integrated metrics/reporting/experiments, disable potentially insecure/invasive/[undesirable](https://en.wikipedia.org/wiki/Feature_creep) features
 * Disable WebIDE [ [1](https://trac.torproject.org/projects/tor/ticket/16222) [2](https://developer.mozilla.org/docs/Tools/WebIDE) ]
 * Disable remote debugging [ [1](https://developer.mozilla.org/en-US/docs/Tools/Remote_Debugging/Debugging_Firefox_Desktop) [2](https://developer.mozilla.org/en-US/docs/Tools/Tools_Toolbox#Advanced_settings) ]
-* Disable Mozilla telemetry/experiments [ [1](https://wiki.mozilla.org/Platform/Features/Telemetry) [2](https://wiki.mozilla.org/Telemetry/) [3](https://www.mozilla.org/en-US/legal/privacy/firefox.html#telemetry) [4](https://support.mozilla.org/t5/Firefox-crashes/Mozilla-Crash-Reporter/ta-p/1715) [5](https://wiki.mozilla.org/Security/Reviews/Firefox6/ReviewNotes/telemetry) [6](https://gecko.readthedocs.org/en/latest/toolkit/components/telemetry/telemetry/preferences.html) [7](https://wiki.mozilla.org/Telemetry/Experiments) ]
+* Disable Mozilla telemetry/experiments [ [1](https://wiki.mozilla.org/Platform/Features/Telemetry) [2](https://wiki.mozilla.org/Privacy/Reviews/Telemetry) [3](https://wiki.mozilla.org/Telemetry) [4](https://www.mozilla.org/en-US/legal/privacy/firefox.html#telemetry) [5](https://support.mozilla.org/t5/Firefox-crashes/Mozilla-Crash-Reporter/ta-p/1715) [6](https://wiki.mozilla.org/Security/Reviews/Firefox6/ReviewNotes/telemetry) [7](https://gecko.readthedocs.io/en/latest/browser/experiments/experiments/manifest.html) [8](https://wiki.mozilla.org/Telemetry/Experiments) ]
+* Disallow Necko to do A/B testing
+* Disable sending Firefox crash reports to Mozilla servers [ [1](https://wiki.mozilla.org/Breakpad) [2](http://kb.mozillazine.org/Breakpad) [3](https://dxr.mozilla.org/mozilla-central/source/toolkit/crashreporter) [4](https://bugzilla.mozilla.org/show_bug.cgi?id=411490) ]
+* Disable sending reports of tab crashes to Mozilla (about:tabcrashed), don't nag user about unsent crash reports [ [1](https://hg.mozilla.org/mozilla-central/file/tip/browser/app/profile/firefox.js) ]
+* Disable FlyWeb (discovery of LAN/proximity IoT devices that expose a Web interface) [ [1](https://wiki.mozilla.org/FlyWeb) [2](https://wiki.mozilla.org/FlyWeb/Security_scenarios) [3](https://docs.google.com/document/d/1eqLb6cGjDL9XooSYEEo7mE-zKQ-o-AuDTcEyNhfBMBM/edit) [4](http://www.ghacks.net/2016/07/26/firefox-flyweb) ]
+* Disable Firefox Sync [ [1](https://wiki.mozilla.org/Services/Sync) ]
 * Disable the UITour backend [ [1](https://trac.torproject.org/projects/tor/ticket/19047#comment:3) ]
 * Enable Firefox Tracking Protection [ [1](https://wiki.mozilla.org/Security/Tracking_protection) [2](https://support.mozilla.org/en-US/kb/tracking-protection-firefox) [3](https://support.mozilla.org/en-US/kb/tracking-protection-pbm) [4](https://kontaxis.github.io/trackingprotectionfirefox/) [5](https://feeding.cloud.geek.nz/posts/how-tracking-protection-works-in-firefox/) ]
 * Enable hardening against various fingerprinting vectors (Tor Uplift project) [ [1](https://wiki.mozilla.org/Security/Tor_Uplift/Tracking) ]

--- a/README.md
+++ b/README.md
@@ -511,6 +511,7 @@ For more information, see [CONTRIBUTING](https://github.com/pyllyukko/user.js/bl
 
 * **[CVEs for Firefox - mitre.org](https://cve.mitre.org/cgi-bin/cvekey.cgi?keyword=firefox)**
 * [CVEs for Firefox - cvedetails.com](https://www.cvedetails.com/vulnerability-list/vendor_id-452/product_id-3264/Mozilla-Firefox.html) 
+* [ghacksuserjs/ghacks-user.js](https://github.com/ghacksuserjs/ghacks-user.js): a similar project and great source of information, with different goals and methodology
 * [About:config entries - MozillaZine](http://kb.mozillazine.org/About:config_entries)
 * [Security and privacy-related preferences - MozillaZine](http://kb.mozillazine.org/Category:Security_and_privacy-related_preferences)
 * [Diff between various Firefox .js configurations in upcoming releases](https://cat-in-136.github.io/) **([RSS](https://cat-in-136.github.io/feed.xml))**

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ HTML5 / [APIs](https://wiki.mozilla.org/WebAPI) / [DOM](https://en.wikipedia.org
 * Disable WebRTC entirely to prevent leaking internal IP addresses (Firefox < 42)
 * Don't reveal your internal IP when WebRTC is enabled (Firefox >= 42) [ [1](https://wiki.mozilla.org/Media/WebRTC/Privacy) [2](https://github.com/beefproject/beef/wiki/Module%3A-Get-Internal-IP-WebRTC) ]
 * Disable WebRTC getUserMedia, screen sharing, audio capture, video capture [ [1](https://wiki.mozilla.org/Media/getUserMedia) [2](https://blog.mozilla.org/futurereleases/2013/01/12/capture-local-camera-and-microphone-streams-with-getusermedia-now-enabled-in-firefox/) [3](https://developer.mozilla.org/en-US/docs/Web/API/Navigator) ]
-* Disable battery API (<52) [ [1](https://developer.mozilla.org/en-US/docs/Web/API/BatteryManager) [2](https://bugzilla.mozilla.org/show_bug.cgi?id=1313580) ]
+* Disable battery API (Firefox < 52) [ [1](https://developer.mozilla.org/en-US/docs/Web/API/BatteryManager) [2](https://bugzilla.mozilla.org/show_bug.cgi?id=1313580) ]
 * Disable telephony API [ [1](https://wiki.mozilla.org/WebAPI/Security/WebTelephony) ]
 * Disable DOM timing API [ [1](https://wiki.mozilla.org/Security/Reviews/Firefox/NavigationTimingAPI) ]
 * Disable "beacon" asynchronous HTTP transfers (used for analytics) [ [1](https://developer.mozilla.org/en-US/docs/Web/API/navigator.sendBeacon) ]
@@ -378,6 +378,7 @@ Hardening your often implies a trade-off with ease-of-use and comes with reduced
 <!-- BEGIN PROBLEMS-LIMITATIONS -->
 * Disabling ServiceWorkers breaks functionality on some sites (Google Street View...)
 * Disabling DOM storage is known to cause`TypeError: localStorage is null` errors
+* Disabling WebRTC breaks peer-to-peer file sharing tools (reep.io ...)
 * IndexedDB could be used for tracking purposes, but is required for some add-ons to work (notably uBlock), so is left enabled
 * Firefox Hello requires setting `media.peerconnection.enabled` and `media.getusermedia.screensharing.enabled` to true, `security.OCSP.require` to false to work.
 * Do No Track must be enabled manually

--- a/README.md
+++ b/README.md
@@ -11,11 +11,12 @@ make it more secure.
 
 * Limit the possibilities to track the user through [web analytics](https://en.wikipedia.org/wiki/Web_analytics).
 * Harden the browser against known data disclosure or code execution vulnerabilities.
-* Limit the browser from storing anything even remotely sensitive persistently
-* Make sure the browser doesn't reveal too much information to [shoulder surfers](https://en.wikipedia.org/wiki/Shoulder_surfing_%28computer_security%29)
-* Harden the browser's encryption (cipher suites, protocols, trusted CAs)
-* Hopefully limit the attack surface by disabling various features
-* Still be usable in daily use
+* Limit the browser from storing anything even remotely sensitive persistently.
+* Make sure the browser doesn't reveal too much information to [shoulder surfers](https://en.wikipedia.org/wiki/Shoulder_surfing_%28computer_security%29).
+* Harden the browser's encryption (cipher suites, protocols, trusted CAs).
+* Limit possibilities to uniquely identify the browser/device using [browser fingerpriting](https://en.wikipedia.org/wiki/Device_fingerprint).
+* Hopefully limit the attack surface by disabling various features.
+* Still be usable in daily use.
 
 ### How to achieve this?
 
@@ -23,6 +24,7 @@ There are several parts to all this and they are:
 
 * [Downloading](#download) and [installing](#installation) the `user.js` file.
 * Reading about and applying [further hardening](#further-hardening) techniques.
+* _Optional:_ Modifying `user.js` to adapt it to your web browser usage.
 
 ----------------------------------------------
 
@@ -61,7 +63,22 @@ To enable the Profile Manager, run Firefox with
 [command-line arguments](http://kb.mozillazine.org/Command_line_arguments):
 `firefox --no-remote -P`
 
-### System-wide installation
+### System-wide installation (all platforms)
+
+Copy `user.js` to the Firefox installation directory. The file should be located at:
+
+| OS             | Path                                                       |
+| -------------- | ---------------------------------------------------------- |
+| Windows        | `C:\Program Files (x86)\Mozilla Firefox\mozilla.cfg`       |
+| Linux          | `/etc/firefox/firefox.js`                                  |
+| Linux (Debian) | `/etc/firefox-esr/firefox-esr.js`                          |
+| OS X           | `/Applications/Firefox.app/Contents/Resources/mozilla.cfg` |
+
+In `user.js`, Change `user_pref(` to  one of:
+ * `pref(` (the value will be used as default value on Firefox profile creation, it can be changed in `about:config`)
+ * `lockPref(` (the value will be used as default value on Firefox profile creation, will be locked and can't be changed) in `user.js` or in Firefox's `about:config` or settings.
+
+#### Additional installation steps for Windows/OSX
 
 Create `local-settings.js` in Firefox installation directory, with the following contents:
 
@@ -75,22 +92,7 @@ This file should be located at:
 | OS      | Path                                                         |
 | ------- | ------------------------------------------------------------ |
 | Windows | `C:\Program Files (x86)\Mozilla Firefox\default\pref\`       |
-| Linux   |**This file is not required**                                 |
 | OS X    | `/Applications/Firefox.app/Contents/Resources/defaults/pref` |
-
-
-In `user.js`, Change `user_pref(` to  one of:
- * `pref(` (the value will be used as default value on Firefox profile creation, it can be changed in `about:config`)
- * `lockPref(` (the value will be used as default value on Firefox profile creation, will be locked and can't be changed) in `user.js` or in Firefox's `about:config` or settings.
-
-Copy `user.js` to the Firefox installation directory. The file should be located at:
-
-| OS             | Path                                                       |
-| -------------- | ---------------------------------------------------------- |
-| Windows        | `C:\Program Files (x86)\Mozilla Firefox\mozilla.cfg`       |
-| Linux          | `/etc/firefox/firefox.js`                                  |
-| Linux (Debian) | `/etc/firefox-esr/firefox-esr.js`                          |
-| OS X           | `/Applications/Firefox.app/Contents/Resources/mozilla.cfg` |
 
 ### Updating using git
 
@@ -333,11 +335,15 @@ This section tweaks the cipher suites used by Firefox. The idea is to support on
 * By default **your browser trusts 100's of [Certificate Authorities](https://en.wikipedia.org/wiki/Certificate_authority)** (CAs) from various organizations to guarantee privacy of your encrypted communications with websites. Some CAs have been known for misusing or deliberately abusing this power in the past, and **a single malicious CA can compromise all** your encrypted communications! Follow [this document](CAs.md) to only trust a selected, trimmed-down list of CAs.
 * Keep your browser updated! If you check [Firefox's security advisories](https://www.mozilla.org/security/known-vulnerabilities/firefox.html), you'll see that pretty much every new version of Firefox contains some security updates. If you don't keep your browser updated, you've already lost the game.
 * Disable/uninstall all unnecessary extensions and plugins!
+* Use long and **unique** passwords/passphrases for each website/service.
+* Prefer open-source, reviewed and audited software and operating systems whenever possible.
+* Do not transmit information meant to be private over unencrypted communication channels.
 * Use a search engine that doesn't track its users, and set it as default search engine.
 * If a plugin is absolutely required, [check for plugin updates](https://www.mozilla.org/en-US/plugincheck/)
 * Create different [profiles][15] for different purposes
 * Change the Firefox's built-in tracking protection to use the [strict list](https://support.mozilla.org/en-US/kb/tracking-protection-pbm?as=u#w_change-your-block-list)
 * Change the timezone for Firefox by using the ```TZ``` environment variable (see [here](https://wiki.archlinux.org/index.php/Firefox_privacy#Change_browser_time_zone)) to reduce it's value in browser fingerprinting
+* If you are concerned about more advanced threats, use specialized hardened operating systems and browsers such as [Tails](https://tails.boum.org/) or [Tor Brower Bundle](https://www.torproject.org/projects/torbrowser.html.en)
 
 
 ### Add-ons
@@ -401,6 +407,7 @@ In addition see the current [issues](https://github.com/pyllyukko/user.js/issues
 
 No. Please read [Known problems and limitations](#known-problems-and-limitations), the project's
 [issue](https://github.com/pyllyukko/user.js/issues) tracker, and report new issues there.
+Please open separate issues for each individual problem/question you may have.
 
 > Why are obsolete/deprecated entries included in the user.js file?
 
@@ -504,6 +511,7 @@ For more information, see [CONTRIBUTING](https://github.com/pyllyukko/user.js/bl
 * [Advices from Mozilla Firefox on privacy and government surveillance](https://www.mozilla.org/en-US/teach/smarton/surveillance/)
 * [Polaris - advance privacy technnology for the web](https://wiki.mozilla.org/Polaris)
 * [Mozilla Privacy Principles](https://wiki.mozilla.org/Privacy/Principles)
+* [List of Firefox "about:" URLs](https://developer.mozilla.org/en-US/Firefox/The_about_protocol)
 * [Mozilla preferences for uber-geeks](https://developer.mozilla.org/en-US/docs/Mozilla/Preferences/Mozilla_preferences_for_uber-geeks)
 * [Privacy & Security related add-ons](https://addons.mozilla.org/firefox/extensions/privacy-security/) ([RSS](https://addons.mozilla.org/en-US/firefox/extensions/privacy-security/format:rss?sort=featured))
 

--- a/README.md
+++ b/README.md
@@ -196,8 +196,8 @@ Disable Firefox integrated metrics/reporting/experiments, disable potentially in
 * Disable remote debugging [ [1](https://developer.mozilla.org/en-US/docs/Tools/Remote_Debugging/Debugging_Firefox_Desktop) [2](https://developer.mozilla.org/en-US/docs/Tools/Tools_Toolbox#Advanced_settings) ]
 * Disable Mozilla telemetry/experiments [ [1](https://wiki.mozilla.org/Platform/Features/Telemetry) [2](https://wiki.mozilla.org/Telemetry/) [3](https://www.mozilla.org/en-US/legal/privacy/firefox.html#telemetry) [4](https://support.mozilla.org/t5/Firefox-crashes/Mozilla-Crash-Reporter/ta-p/1715) [5](https://wiki.mozilla.org/Security/Reviews/Firefox6/ReviewNotes/telemetry) [6](https://gecko.readthedocs.org/en/latest/toolkit/components/telemetry/telemetry/preferences.html) [7](https://wiki.mozilla.org/Telemetry/Experiments) ]
 * Disable the UITour backend [ [1](https://trac.torproject.org/projects/tor/ticket/19047#comment:3) ]
-* Enable Firefox Tracking Protection [ [1](https://wiki.mozilla.org/Security/Tracking_protection) [2](https://support.mozilla.org/en-US/kb/tracking-protection-firefox) [3](https://support.mozilla.org/en-US/kb/tracking-protection-pbm) ]
-* Resist fingerprinting via window.screen and CSS media queries and other techniques [ [1](https://bugzilla.mozilla.org/show_bug.cgi?id=418986) [2](https://bugzilla.mozilla.org/show_bug.cgi?id=1281949) [3](https://bugzilla.mozilla.org/show_bug.cgi?id=1281963) ]
+* Enable Firefox Tracking Protection [ [1](https://wiki.mozilla.org/Security/Tracking_protection) [2](https://support.mozilla.org/en-US/kb/tracking-protection-firefox) [3](https://support.mozilla.org/en-US/kb/tracking-protection-pbm) [4](https://kontaxis.github.io/trackingprotectionfirefox/) [5](https://feeding.cloud.geek.nz/posts/how-tracking-protection-works-in-firefox/) ]
+* Enable hardening against various fingerprinting vectors (Tor Uplift project) [ [1](https://wiki.mozilla.org/Security/Tor_Uplift/Tracking) ]
 * Disable the built-in PDF viewer [ [1](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-2743) [2](https://blog.mozilla.org/security/2015/08/06/firefox-exploit-found-in-the-wild/) [3](https://www.mozilla.org/en-US/security/advisories/mfsa2015-69/) ]
 * Disable collection/sending of the health report (healthreport.sqlite*) [ [1](https://support.mozilla.org/en-US/kb/firefox-health-report-understand-your-browser-perf) [2](https://gecko.readthedocs.org/en/latest/toolkit/components/telemetry/telemetry/preferences.html) ]
 * Disable new tab tile ads & preload [ [1](http://www.thewindowsclub.com/disable-remove-ad-tiles-from-firefox) [2](http://forums.mozillazine.org/viewtopic.php?p=13876331#p13876331) [3](https://wiki.mozilla.org/Tiles/Technical_Documentation#Ping) [4](https://gecko.readthedocs.org/en/latest/browser/browser/DirectoryLinksProvider.html#browser-newtabpage-directory-source) [5](https://gecko.readthedocs.org/en/latest/browser/browser/DirectoryLinksProvider.html#browser-newtabpage-directory-ping) ]
@@ -321,50 +321,36 @@ This section tweaks the cipher suites used by Firefox. The idea is to support on
 * By default **your browser trusts 100's of [Certificate Authorities](https://en.wikipedia.org/wiki/Certificate_authority)** (CAs) from various organizations to guarantee privacy of your encrypted communications with websites. Some CAs have been known for misusing or deliberately abusing this power in the past, and **a single malicious CA can compromise all** your encrypted communications! Follow [this document](CAs.md) to only trust a selected, trimmed-down list of CAs.
 * Keep your browser updated! If you check [Firefox's security advisories](https://www.mozilla.org/security/known-vulnerabilities/firefox.html), you'll see that pretty much every new version of Firefox contains some security updates. If you don't keep your browser updated, you've already lost the game.
 * Disable/uninstall all unnecessary extensions and plugins!
+* Use a search engine that doesn't track its users, and set it as default search engine.
 * If a plugin is absolutely required, [check for plugin updates](https://www.mozilla.org/en-US/plugincheck/)
 * Create different [profiles][15] for different purposes
 * Change the Firefox's built-in tracking protection to use the [strict list](https://support.mozilla.org/en-US/kb/tracking-protection-pbm?as=u#w_change-your-block-list)
 * Change the timezone for Firefox by using the ```TZ``` environment variable (see [here](https://wiki.archlinux.org/index.php/Firefox_privacy#Change_browser_time_zone)) to reduce it's value in browser fingerprinting
-* Completely block unencrypted communications using the `HTTPS Everywhere` toolbar button > `Block all unencrypted requests`. This will break websites where HTTPS is not available.
+
 
 ### Add-ons
 
 Here is a list of the most essential security and privacy enhancing add-ons that you should consider using:
 
-* [Certificate Patrol](http://patrol.psyced.org/)
-  * I recommend setting the 'Store certificates even when in [Private Browsing][8] Mode' to get full benefit out of certpatrol, even though it stores information about the sites you visit
-* [HTTPS Everywhere](https://www.eff.org/https-everywhere) and [HTTPS by default](https://addons.mozilla.org/firefox/addon/https-by-default/)
-* [NoScript](https://noscript.net/)
-* [DuckDuckGo Plus](https://addons.mozilla.org/firefox/addon/duckduckgo-for-firefox/) (instead of Google)
-* [No Resource URI Leak](https://addons.mozilla.org/firefox/addon/no-resource-uri-leak/) (see [#163](https://github.com/pyllyukko/user.js/issues/163))
-* [Decentraleyes](https://addons.mozilla.org/firefox/addon/decentraleyes/)
-* [Canvas Blocker](https://addons.mozilla.org/firefox/addon/canvasblocker/) ([Source code](https://github.com/kkapsner/CanvasBlocker))
-
-### Tracking protection
-
-Tracking protection is one of the most important technologies that you need. The usual recommendation has been to run the [Ghostery](https://www.ghostery.com/) extension, but as it is made by a [potentially evim(tm) advertising company](https://en.wikipedia.org/wiki/Ghostery#Criticism), some people feel that is not to be trusted. One notable alternative is to use [uBlock](https://github.com/gorhill/uBlock), which can also be found at [Mozilla AMO](https://addons.mozilla.org/firefox/addon/ublock-origin/).
-
-Ghostery is still viable option, but be sure to disable the [GhostRank](https://www.ghostery.com/en/faq#q5-general) feature.
-
-Do note, that this user.js also enables Mozilla's built-in [tracking protection][12], but as that's quite new feature it is to be considered only as a fallback and not a complete solution. As it utilizes [Disconnect's list](https://support.mozilla.org/en-US/kb/tracking-protection-firefox#w_what-is-tracking-protection), recommending Disconnect seems redundant.
-
-So to summarize, pick one between Ghostery and uBlock, depending on your personal preferences.
-
-See also:
-* [Mozilla Lightbeam][13] extension
-* [Privacy Badger](https://www.eff.org/privacybadger) extension from EFF (also to be considered as an additional security measure and not a complete solution)
-* [Web Browser Addons](https://prism-break.org/en/subcategories/gnu-linux-web-browser-addons/) section in [PRISM break](https://prism-break.org/)
-* [\[Talk\] Ghostery Vs. Disconnect.me Vs. uBlock #16](https://github.com/pyllyukko/user.js/issues/16)
-* [Ghostery sneaks in new promotional messaging system #47](https://github.com/pyllyukko/user.js/issues/47)
-* [Are We Private Yet?](https://web.archive.org/web/20150801031411/http://www.areweprivateyet.com/) site (made by Ghostery, archived)
-* [Tracking Protection in Firefox For Privacy and Performance](https://kontaxis.github.io/trackingprotectionfirefox/#papers) paper
-* [How Tracking Protection works in Firefox](https://feeding.cloud.geek.nz/posts/how-tracking-protection-works-in-firefox/)
-
-### Add-ons for mobile platforms
-
-* [NoScript Anywhere](https://noscript.net/nsa/)
-* [uBlock](https://addons.mozilla.org/android/addon/ublock-origin/)
+* [uBlock Origin](https://addons.mozilla.org/firefox/addon/ublock-origin/)
+  * For additional protection against cross-site requests, set it to [Hard mode](https://github.com/gorhill/uBlock/wiki/Blocking-mode:-hard-mode) (experienced users) - the default is [Easy mode](https://github.com/gorhill/uBlock/wiki/Blocking-mode:-easy-mode)
 * [HTTPS Everywhere](https://www.eff.org/https-everywhere)
+  * For additional protection, enable `Block all unencrypted requests` in the toolbar button menu. This will break websites where HTTPS is not available.
+* [Certificate Patrol](http://patrol.psyced.org/) (experienced users)
+  * Setting `Store certificates even when in Private Browsing mode` improves usability (but stores information about the sites you visit)
+* [HTTPS by default](https://addons.mozilla.org/firefox/addon/https-by-default/)
+* [NoScript](https://noscript.net/)
+* [No Resource URI Leak](https://addons.mozilla.org/firefox/addon/no-resource-uri-leak/)
+* [Decentraleyes](https://addons.mozilla.org/firefox/addon/decentraleyes/)
+* [Canvas Blocker](https://addons.mozilla.org/firefox/addon/canvasblocker/)
+
+Additional add-ons that you might consider using or reading about:
+
+* [uMatrix](https://addons.mozilla.org/en-US/firefox/addon/umatrix/) (experienced users) 
+* [Privacy Badger](https://www.eff.org/privacybadger)
+* [Mozilla Lightbeam](https://www.mozilla.org/en-US/lightbeam/)
+* [PRISM Break Web Browser Addons section](https://prism-break.org/en/subcategories/gnu-linux-web-browser-addons/)
+* [Ghostery](https://www.ghostery.com/) (proprietary software, maintained by [an advertising company](https://en.wikipedia.org/wiki/Ghostery))
 
 ## Known problems and limitations
 
@@ -538,5 +524,4 @@ For more information, see [CONTRIBUTING](https://github.com/pyllyukko/user.js/bl
 [8]: https://support.mozilla.org/en-US/kb/Private%20Browsing
 [9]: https://bugzilla.mozilla.org/show_bug.cgi?id=822869
 [12]: https://support.mozilla.org/en-US/kb/tracking-protection-firefox
-[13]: https://www.mozilla.org/en-US/lightbeam/
 [15]: https://mzl.la/NYhKHH

--- a/README.md
+++ b/README.md
@@ -333,11 +333,12 @@ This section tweaks the cipher suites used by Firefox. The idea is to support on
 Here is a list of the most essential security and privacy enhancing add-ons that you should consider using:
 
 * [uBlock Origin](https://addons.mozilla.org/firefox/addon/ublock-origin/)
-  * For additional protection against cross-site requests, set it to [Hard mode](https://github.com/gorhill/uBlock/wiki/Blocking-mode:-hard-mode) (experienced users) - the default is [Easy mode](https://github.com/gorhill/uBlock/wiki/Blocking-mode:-easy-mode)
+  * For additional protection, enable more blocklists in the addon dashboard.
+  * For additional protection, set it to [Hard mode](https://github.com/gorhill/uBlock/wiki/Blocking-mode:-hard-mode) (experienced users) - the default is [Easy mode](https://github.com/gorhill/uBlock/wiki/Blocking-mode:-easy-mode)
 * [HTTPS Everywhere](https://www.eff.org/https-everywhere)
   * For additional protection, enable `Block all unencrypted requests` in the toolbar button menu. This will break websites where HTTPS is not available.
 * [Certificate Patrol](http://patrol.psyced.org/) (experienced users)
-  * Setting `Store certificates even when in Private Browsing mode` improves usability (but stores information about the sites you visit)
+  * Setting `Store certificates even when in Private Browsing mode` improves usability. This will store information about sites you visit.
 * [HTTPS by default](https://addons.mozilla.org/firefox/addon/https-by-default/)
 * [NoScript](https://noscript.net/)
 * [No Resource URI Leak](https://addons.mozilla.org/firefox/addon/no-resource-uri-leak/)

--- a/ignore.list
+++ b/ignore.list
@@ -1,0 +1,12 @@
+// List of preferences to ignore during comparison with Firefox upstream prefs
+// Preference names must use double quotes
+
+// Don't touch Firefox social API preferences, fully opt-in, WONTFIX
+"toolkit.telemetry.unifiedIsOptIn"
+"social.whitelist"
+"social.toast-notifications.enabled"
+"social.shareDirectory"
+"social.remote-install.enabled"
+"social.directories"
+"social.share.activationPanelEnabled"
+"social.enabled"

--- a/user.js
+++ b/user.js
@@ -368,6 +368,14 @@ user_pref("experiments.manifest.uri",				"");
 // PREF: Disallow Necko to do A/B testing
 user_pref("network.allow-experiments",			false);
 
+// PREF: Disable sending Firefox crash reports to Mozilla servers
+// https://wiki.mozilla.org/Breakpad
+// http://kb.mozillazine.org/Breakpad
+// https://dxr.mozilla.org/mozilla-central/source/toolkit/crashreporter
+// https://bugzilla.mozilla.org/show_bug.cgi?id=411490
+// A list of submitted crash reports can be found at about:crashes
+user_pref("breakpad.reportURL",			"");
+
 // PREF: Disable the UITour backend
 // https://trac.torproject.org/projects/tor/ticket/19047#comment:3
 user_pref("browser.uitour.enabled",				false);

--- a/user.js
+++ b/user.js
@@ -188,6 +188,11 @@ user_pref("browser.search.geoSpecificDefaults.url",	"");
 // http://kb.mozillazine.org/Clipboard.autocopy
 user_pref("clipboard.autocopy",					false);
 
+// PREF: Prevent leaking application locale/date format using JavaScript
+// https://bugzilla.mozilla.org/show_bug.cgi?id=867501
+// https://hg.mozilla.org/mozilla-central/rev/52d635f2b33d
+user_pref("javascript.use_us_english_locale", 	true);
+
 // PREF: Do not submit invalid URIs entered in the address bar to the default search engine
 // http://kb.mozillazine.org/Keyword.enabled
 user_pref("keyword.enabled",					false);

--- a/user.js
+++ b/user.js
@@ -381,6 +381,13 @@ user_pref("breakpad.reportURL",			"");
 user_pref("browser.tabs.crashReporting.sendReport",			false);
 user_pref("browser.crashReports.unsubmittedCheck.enabled",	false);
 
+// PREF: Disable FlyWeb (discovery of LAN/proximity IoT devices that expose a Web interface)
+// https://wiki.mozilla.org/FlyWeb
+// https://wiki.mozilla.org/FlyWeb/Security_scenarios
+// https://docs.google.com/document/d/1eqLb6cGjDL9XooSYEEo7mE-zKQ-o-AuDTcEyNhfBMBM/edit
+// http://www.ghacks.net/2016/07/26/firefox-flyweb
+user_pref("dom.flyweb.enabled",	false);
+
 // PREF: Disable the UITour backend
 // https://trac.torproject.org/projects/tor/ticket/19047#comment:3
 user_pref("browser.uitour.enabled",				false);

--- a/user.js
+++ b/user.js
@@ -537,9 +537,14 @@ user_pref("network.cookie.cookieBehavior",			1);
 user_pref("network.cookie.thirdparty.sessionOnly",		true);
 
 // PREF: Spoof User-agent (disabled)
-//user_pref("general.useragent.override",				"Mozilla/5.0 (Windows NT 6.1; rv:31.0) Gecko/20100101 Firefox/31.0");
-//user_pref("general.platform.override",				"Win32");
-//user_pref("general.oscpu.override",				"Windows NT 6.1");
+// Spoofing referer has no real security/privacy advantages, real UA might be derived by other means, might break functionality on some sites.
+// Left commented out for reference purposes, ESR/TBB values.
+//user_pref("general.useragent.override", "Mozilla/5.0 (Windows NT 6.1; rv:45.0) Gecko/20100101 Firefox/45.0");
+//user_pref("general.buildID.override", "20100101");
+//user_pref("general.appname.override", "Netscape");
+//user_pref("general.appversion.override", "5.0 (Windows)");
+//user_pref("general.platform.override", "Win32");
+//user_pref("general.oscpu.override", "Windows NT 6.1");
 
 /*******************************************************************************
  * SECTION: Caching                                                            *

--- a/user.js
+++ b/user.js
@@ -289,11 +289,18 @@ user_pref("extensions.getAddons.cache.enabled",			false);
 // https://support.mozilla.org/t5/Firefox/how-do-I-prevent-autoamtic-updates-in-a-50-user-environment/td-p/144287
 user_pref("lightweightThemes.update.enabled", 			false);
 
-// PREF: Flash plugin state - never activate
+// PREF: Flash Player plugin state - never activate
 // http://kb.mozillazine.org/Flash_plugin
 user_pref("plugin.state.flash",					0);
+
 // PREF: Java plugin state - never activate
 user_pref("plugin.state.java",					0);
+
+// PREF: Disable sending Flash Player crash reports
+user_pref("dom.ipc.plugins.flash.subprocess.crashreporter.enabled",	false);
+
+// PREF: When Flash crash reports are enabled, don't send the visited URL in the crash report
+user_pref("dom.ipc.plugins.reportCrashURL",							false);
 
 // PREF: Disable Gnome Shell Integration
 user_pref("plugin.state.libgnome-shell-browser-plugin",		0);

--- a/user.js
+++ b/user.js
@@ -376,6 +376,11 @@ user_pref("network.allow-experiments",			false);
 // A list of submitted crash reports can be found at about:crashes
 user_pref("breakpad.reportURL",			"");
 
+// PREF: Disable sending reports of tab crashes to Mozilla (about:tabcrashed), don't nag user about unsent crash reports
+// https://hg.mozilla.org/mozilla-central/file/tip/browser/app/profile/firefox.js
+user_pref("browser.tabs.crashReporting.sendReport",			false);
+user_pref("browser.crashReports.unsubmittedCheck.enabled",	false);
+
 // PREF: Disable the UITour backend
 // https://trac.torproject.org/projects/tor/ticket/19047#comment:3
 user_pref("browser.uitour.enabled",				false);

--- a/user.js
+++ b/user.js
@@ -285,6 +285,10 @@ user_pref("security.dialog_enable_delay",			1000);
 // https://blog.mozilla.org/addons/how-to-opt-out-of-add-on-metadata-updates/
 user_pref("extensions.getAddons.cache.enabled",			false);
 
+// PREF: Opt-out of themes (Persona) updates
+// https://support.mozilla.org/t5/Firefox/how-do-I-prevent-autoamtic-updates-in-a-50-user-environment/td-p/144287
+user_pref("lightweightThemes.update.enabled", 			false);
+
 // PREF: Flash plugin state - never activate
 // http://kb.mozillazine.org/Flash_plugin
 user_pref("plugin.state.flash",					0);

--- a/user.js
+++ b/user.js
@@ -52,6 +52,7 @@ user_pref("dom.mozTCPSocket.enabled",				false);
 user_pref("dom.netinfo.enabled",				false);
 
 // PREF: Disable WebRTC entirely to prevent leaking internal IP addresses (Firefox < 42)
+// NOTICE: Disabling WebRTC breaks peer-to-peer file sharing tools (reep.io ...)
 user_pref("media.peerconnection.enabled",			false);
 
 // PREF: Don't reveal your internal IP when WebRTC is enabled (Firefox >= 42)
@@ -69,7 +70,7 @@ user_pref("media.navigator.video.enabled",			false);
 user_pref("media.getusermedia.screensharing.enabled",		false);
 user_pref("media.getusermedia.audiocapture.enabled",		false);
 
-// PREF: Disable battery API (<52)
+// PREF: Disable battery API (Firefox < 52)
 // https://developer.mozilla.org/en-US/docs/Web/API/BatteryManager
 // https://bugzilla.mozilla.org/show_bug.cgi?id=1313580
 user_pref("dom.battery.enabled",				false);
@@ -439,7 +440,7 @@ user_pref("browser.newtabpage.directory.source",		"data:text/plain,{}");
 // https://trac.torproject.org/projects/tor/ticket/19047
 user_pref("browser.selfsupport.url",				"");
 
-// PREF: Disable Firefox Hello (disabled) (<49)
+// PREF: Disable Firefox Hello (disabled) (Firefox < 49)
 // https://wiki.mozilla.org/Loop
 // https://support.mozilla.org/t5/Chat-and-share/Support-for-Hello-discontinued-in-Firefox-49/ta-p/37946
 // NOTICE: Firefox Hello requires setting `media.peerconnection.enabled` and `media.getusermedia.screensharing.enabled` to true, `security.OCSP.require` to false to work.

--- a/user.js
+++ b/user.js
@@ -352,16 +352,21 @@ user_pref("devtools.debugger.force-local",			true);
 
 // PREF: Disable Mozilla telemetry/experiments
 // https://wiki.mozilla.org/Platform/Features/Telemetry
-// https://wiki.mozilla.org/Telemetry/
+// https://wiki.mozilla.org/Privacy/Reviews/Telemetry
+// https://wiki.mozilla.org/Telemetry
 // https://www.mozilla.org/en-US/legal/privacy/firefox.html#telemetry
 // https://support.mozilla.org/t5/Firefox-crashes/Mozilla-Crash-Reporter/ta-p/1715
 // https://wiki.mozilla.org/Security/Reviews/Firefox6/ReviewNotes/telemetry
-// https://gecko.readthedocs.org/en/latest/toolkit/components/telemetry/telemetry/preferences.html
+// https://gecko.readthedocs.io/en/latest/browser/experiments/experiments/manifest.html
 // https://wiki.mozilla.org/Telemetry/Experiments
 user_pref("toolkit.telemetry.enabled",				false);
 user_pref("toolkit.telemetry.unified",				false);
 user_pref("experiments.supported",				false);
 user_pref("experiments.enabled",				false);
+user_pref("experiments.manifest.uri",				"");
+
+// PREF: Disallow Necko to do A/B testing
+user_pref("network.allow-experiments",			false);
 
 // PREF: Disable the UITour backend
 // https://trac.torproject.org/projects/tor/ticket/19047#comment:3

--- a/user.js
+++ b/user.js
@@ -344,6 +344,8 @@ user_pref("browser.uitour.enabled",				false);
 // https://wiki.mozilla.org/Security/Tracking_protection
 // https://support.mozilla.org/en-US/kb/tracking-protection-firefox
 // https://support.mozilla.org/en-US/kb/tracking-protection-pbm
+// https://kontaxis.github.io/trackingprotectionfirefox/
+// https://feeding.cloud.geek.nz/posts/how-tracking-protection-works-in-firefox/
 user_pref("privacy.trackingprotection.enabled",			true);
 user_pref("privacy.trackingprotection.pbmode.enabled",		true);
 

--- a/user.js
+++ b/user.js
@@ -170,8 +170,15 @@ user_pref("browser.search.countryCode",				"US");
 user_pref("browser.search.region",				"US");
 user_pref("browser.search.geoip.url",				"");
 
-// PREF: Set locale to en-US (if you are using localized version of FF)
+// PREF: Set Accept-Language HTTP header to en-US regardless of Firefox localization
+// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language
 user_pref("intl.accept_languages",				"en-us, en");
+
+// PREF: Set Firefox locale to en-US
+user_pref("general.useragent.locale",			"en-US");
+
+// PREF: Don't use OS values to determine locale, force using Firefox locale setting
+user_pref("intl.locale.matchOS",				false);
 
 // PREF: Do not automatically send selection to clipboard on some Linux platforms
 // http://kb.mozillazine.org/Clipboard.autocopy

--- a/user.js
+++ b/user.js
@@ -180,6 +180,10 @@ user_pref("general.useragent.locale",			"en-US");
 // PREF: Don't use OS values to determine locale, force using Firefox locale setting
 user_pref("intl.locale.matchOS",				false);
 
+// PREF: Don't use Mozilla-provided location-specific search engines
+user_pref("browser.search.geoSpecificDefaults", 	false);
+user_pref("browser.search.geoSpecificDefaults.url",	"");
+
 // PREF: Do not automatically send selection to clipboard on some Linux platforms
 // http://kb.mozillazine.org/Clipboard.autocopy
 user_pref("clipboard.autocopy",					false);

--- a/user.js
+++ b/user.js
@@ -388,6 +388,10 @@ user_pref("browser.crashReports.unsubmittedCheck.enabled",	false);
 // http://www.ghacks.net/2016/07/26/firefox-flyweb
 user_pref("dom.flyweb.enabled",	false);
 
+// PREF: Disable Firefox Sync
+// https://wiki.mozilla.org/Services/Sync
+user_pref("services.sync.enabled",	false);
+
 // PREF: Disable the UITour backend
 // https://trac.torproject.org/projects/tor/ticket/19047#comment:3
 user_pref("browser.uitour.enabled",				false);

--- a/user.js
+++ b/user.js
@@ -347,10 +347,8 @@ user_pref("browser.uitour.enabled",				false);
 user_pref("privacy.trackingprotection.enabled",			true);
 user_pref("privacy.trackingprotection.pbmode.enabled",		true);
 
-// PREF: Resist fingerprinting via window.screen and CSS media queries and other techniques
-// https://bugzilla.mozilla.org/show_bug.cgi?id=418986
-// https://bugzilla.mozilla.org/show_bug.cgi?id=1281949
-// https://bugzilla.mozilla.org/show_bug.cgi?id=1281963
+// PREF: Enable hardening against various fingerprinting vectors (Tor Uplift project)
+// https://wiki.mozilla.org/Security/Tor_Uplift/Tracking
 user_pref("privacy.resistFingerprinting",			true);
 
 // PREF: Disable the built-in PDF viewer


### PR DESCRIPTION
See commit messages:

```
* c850e47 README: add-ons: add extra blocklists recommendation, shorten addon-specific recommendations
* 97b3166 README: refactor addons section:  * remove lengthy description, just recommend addons, or don't recommend them.  * remove duckduckgo plus, add generic hardening recommendation about privacy-conscious search engines  * store all addon-specific recommendations in the addon section  * Move ghostery to Other addons subsection, add uMatrix to this section  * remove links to issues (use the search feature) * move built-in tracking protection links to user.js tracking protection section * run make - auto-update 'What does it do' section
* 311c51d README: improve FAQ about deprecated preferences, closes #33 #251
* cdf0bf5 simplify privacy.resistfingerprinting references: link to mozilla meta tracking page for this pref change pref description since this is related to more than screen size and media queries
* 47bbbe5 improve comment-out referer spoofing prefs, closes #193
```

See https://github.com/nodiscc/user.js/tree/fixesfixesfixes#add-ons