### PR TITLE
Makefile: downloadffprefs: add Firefox source reference files from #208

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,17 @@ downloadffprefs:
 	https://hg.mozilla.org/mozilla-central/raw-file/$$SOURCEVERSION/modules/libpref/init/all.js \
 	https://hg.mozilla.org/mozilla-central/raw-file/$$SOURCEVERSION/testing/profiles/prefs_general.js \
 	https://hg.mozilla.org/mozilla-central/raw-file/$$SOURCEVERSION/layout/tools/reftest/reftest-preferences.js \
-	https://hg.mozilla.org/mozilla-central/raw-file/$$SOURCEVERSION/js/src/tests/user.js"; \
+	https://hg.mozilla.org/mozilla-central/raw-file/$$SOURCEVERSION/js/src/tests/user.js \
+	https://hg.mozilla.org/mozilla-central/raw-file/$$SOURCEVERSION/browser/app/profile/firefox.js \
+	https://hg.mozilla.org/mozilla-central/raw-file/tip/devtools/client/preferences/debugger.js \
+	https://hg.mozilla.org/mozilla-central/raw-file/tip/devtools/client/preferences/devtools.js \
+	https://hg.mozilla.org/mozilla-central/raw-file/tip/browser/branding/unofficial/pref/firefox-branding.js \
+	https://hg.mozilla.org/mozilla-central/raw-file/tip/browser/branding/official/pref/firefox-branding.js \
+	https://hg.mozilla.org/mozilla-central/raw-file/tip/browser/branding/nightly/pref/firefox-branding.js \
+	https://hg.mozilla.org/mozilla-central/raw-file/tip/browser/branding/aurora/pref/firefox-branding.js \
+	https://hg.mozilla.org/mozilla-central/raw-file/tip/browser/locales/en-US/firefox-l10n.js \
+	https://hg.mozilla.org/mozilla-central/raw-file/tip/devtools/client/webide/webide-prefs.js \
+	https://hg.mozilla.org/mozilla-central/raw-file/tip/browser/app/profile/channel-prefs.js"; \
 	for SOURCEFILE in $$FIREFOX_SOURCE_PREFS; do wget -nv "$$SOURCEFILE" -O - ; done | egrep "(^pref|^user_pref)" | sort --unique >| sourceprefs.js
 
 ######################


### PR DESCRIPTION
Some deprecated/otherwise absent prefs are still detected: http://paste.debian.net/925997/