### PR TITLE
add table of contents, fixes #126;

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ whatdoesitdo:
 # To decrease tests verbosity, comment out unneeded targets
 tests: downloadffprefs checkdeprecated stats cleanup
 
-
 downloadffprefs:
 	@# download and sort all known preferences files from Firefox (mozilla-central) source
 	@# specify wanted Firefox version/revision below (eg. "tip", "FIREFOX_AURORA_45_BASE", "9577ddeaafd85554c2a855f385a87472a089d5c0"). See https://hg.mozilla.org/mozilla-central/tags
@@ -65,3 +64,10 @@ authors:
 	@# generate an AUTHORS file, ordered by number of commits
 	@# to add extra authors/credits, git commit --allow-empty --author="A U Thor <author@example.com>"
 	@git shortlog -sne | cut -f1 --complement >| AUTHORS
+
+toc:
+	@l2headers=$$(egrep "^## " README.md |cut -d" " -f1 --complement ); \
+	echo "$$l2headers" | while read line; do \
+	anchor=$$(echo "$$line" | tr '[:upper:]' '[:lower:]' | sed 's/ /-/g' | sed 's/\?//g'); \
+	echo "* [$$line](#$$anchor)"; \
+	done

--- a/README.md
+++ b/README.md
@@ -28,6 +28,19 @@ There are several parts to all this and they are:
 
 ----------------------------------------------
 
+* [Download](#download)
+* [Installation](#installation)
+* [What does it do?](#what-does-it-do)
+* [Further hardening](#further-hardening)
+* [Known problems and limitations](#known-problems-and-limitations)
+* [FAQ](#faq)
+* [Contributing](#contributing)
+* [Online tests](#online-tests)
+* [References](#references)
+
+
+----------------------------------------------
+
 ## Download
 
 Different download methods are available:


### PR DESCRIPTION
add a Makefile target 'make toc' to generate a markdown TOC from level 2 section headers
(no automatic text replacement in README.md, new TOC must copy-pasted manually from Make output)