### PR TITLE
add various preferences to user.js/ignore.list:

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ HTML5 / [APIs](https://wiki.mozilla.org/WebAPI) / [DOM](https://en.wikipedia.org
 * Make sure the User Timing API does not provide a new high resolution timestamp [ [1](https://trac.torproject.org/projects/tor/ticket/16336) ]
 * Disable Web Audio API [ [1](https://bugzilla.mozilla.org/show_bug.cgi?id=1288359) ]
 * Disable Location-Aware Browsing (geolocation) [ [1](https://www.mozilla.org/en-US/firefox/geolocation/) ]
+* When geolocation is enabled, use Mozilla geolocation service instead of Google [ [1](https://bugzilla.mozilla.org/show_bug.cgi?id=689252) ]
+* When geolocation is enabled, don't log geolocation requests to the console
 * Disable raw TCP socket support (mozTCPSocket) [ [1](https://trac.torproject.org/projects/tor/ticket/18863) [2](https://www.mozilla.org/en-US/security/advisories/mfsa2015-97/) [3](https://developer.mozilla.org/docs/Mozilla/B2G_OS/API/TCPSocket) ]
 * Whether JS can get information about the network/browser connection
 * Disable WebRTC entirely to prevent leaking internal IP addresses (Firefox < 42)
@@ -148,7 +150,8 @@ HTML5 / [APIs](https://wiki.mozilla.org/WebAPI) / [DOM](https://en.wikipedia.org
 * Disable pinging URIs specified in HTML <a> ping= attributes [ [1](http://kb.mozillazine.org/Browser.send_pings) ]
 * When browser pings are enabled, only allow pinging the same host as the origin page [ [1](http://kb.mozillazine.org/Browser.send_pings.require_same_host) ]
 * Disable gamepad input [ [1](https://www.w3.org/TR/gamepad/) ]
-* Disable virtual reality devices [ [1](https://developer.mozilla.org/en-US/Firefox/Releases/36#Interfaces.2FAPIs.2FDOM) ]
+* Disable virtual reality devices APIs [ [1](https://developer.mozilla.org/en-US/Firefox/Releases/36#Interfaces.2FAPIs.2FDOM) [2](https://developer.mozilla.org/en-US/docs/Web/API/WebVR_API) ]
+* Disable vibrator API
 * Disable webGL [ [1](https://en.wikipedia.org/wiki/WebGL) [2](https://www.contextis.com/resources/blog/webgl-new-dimension-browser-exploitation/) ]
 * When webGL is enabled, use the minimum capability mode
 * When webGL is enabled, disable webGL extensions [ [1](https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API#WebGL_debugging_and_testing) ]
@@ -169,6 +172,7 @@ Settings that do not belong to other sections or are user specific preferences.
 * Do not submit invalid URIs entered in the address bar to the default search engine [ [1](http://kb.mozillazine.org/Keyword.enabled) ]
 * Don't trim HTTP off of URLs in the address bar. [ [1](https://bugzilla.mozilla.org/show_bug.cgi?id=665580) ]
 * Don't try to guess domain names when entering an invalid domain name in URL bar [ [1](http://www-archive.mozilla.org/docs/end-user/domain-guessing.html) ]
+* When browser.fixup.alternate.enabled is enabled, do not fix URLs containing 'user:password' data
 * Send DNS request through SOCKS when SOCKS proxying is in use [ [1](https://trac.torproject.org/projects/tor/wiki/doc/TorifyHOWTO/WebBrowsers) ]
 * Don't monitor OS online/offline connection state [ [1](https://trac.torproject.org/projects/tor/ticket/18945) ]
 * Enforce Mixed Content Blocking [ [1](https://support.mozilla.org/t5/Protect-your-privacy/Mixed-content-blocking-in-Firefox/ta-p/10990) [2](https://developer.mozilla.org/en-US/docs/Site_Compatibility_for_Firefox_23#Non-SSL_contents_on_SSL_pages_are_blocked_by_default) [3](https://blog.mozilla.org/tanvi/2013/04/10/mixed-content-blocking-enabled-in-firefox-23/) ]
@@ -192,6 +196,7 @@ Harden preferences related to external plugins
 * Java plugin state - never activate
 * Disable sending Flash Player crash reports
 * When Flash crash reports are enabled, don't send the visited URL in the crash report
+* When Flash is enabled, download and use Mozilla SWF URIs blocklist [ [1](https://bugzilla.mozilla.org/show_bug.cgi?id=1237198) [2](https://github.com/mozilla-services/shavar-plugin-blocklist) ]
 * Disable Gnome Shell Integration
 * Enable plugins click-to-play [ [1](https://wiki.mozilla.org/Firefox/Click_To_Play) [2](https://blog.mozilla.org/security/2012/10/11/click-to-play-plugins-blocklist-style/) ]
 * Updates addons automatically [ [1](https://blog.mozilla.org/addons/how-to-turn-off-add-on-updates/) ]
@@ -214,12 +219,11 @@ Disable Firefox integrated metrics/reporting/experiments, disable potentially in
 * Enable hardening against various fingerprinting vectors (Tor Uplift project) [ [1](https://wiki.mozilla.org/Security/Tor_Uplift/Tracking) ]
 * Disable the built-in PDF viewer [ [1](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-2743) [2](https://blog.mozilla.org/security/2015/08/06/firefox-exploit-found-in-the-wild/) [3](https://www.mozilla.org/en-US/security/advisories/mfsa2015-69/) ]
 * Disable collection/sending of the health report (healthreport.sqlite*) [ [1](https://support.mozilla.org/en-US/kb/firefox-health-report-understand-your-browser-perf) [2](https://gecko.readthedocs.org/en/latest/toolkit/components/telemetry/telemetry/preferences.html) ]
-* Disable new tab tile ads & preload [ [1](http://www.thewindowsclub.com/disable-remove-ad-tiles-from-firefox) [2](http://forums.mozillazine.org/viewtopic.php?p=13876331#p13876331) [3](https://wiki.mozilla.org/Tiles/Technical_Documentation#Ping) [4](https://gecko.readthedocs.org/en/latest/browser/browser/DirectoryLinksProvider.html#browser-newtabpage-directory-source) [5](https://gecko.readthedocs.org/en/latest/browser/browser/DirectoryLinksProvider.html#browser-newtabpage-directory-ping) ]
-* Disable heartbeat [ [1](https://wiki.mozilla.org/Advocacy/heartbeat) [2](https://trac.torproject.org/projects/tor/ticket/19047) ]
+* Disable Heartbeat  (Mozilla user rating telemetry) [ [1](https://wiki.mozilla.org/Advocacy/heartbeat) [2](https://trac.torproject.org/projects/tor/ticket/19047) [3](https://trac.torproject.org/projects/tor/ticket/18738) ]
 * Disable Firefox Hello metrics collection [ [1](https://groups.google.com/d/topic/mozilla.dev.platform/nyVkCx-_sFw/discussion) ]
 * Enable blocking reported web forgeries [ [1](https://wiki.mozilla.org/Security/Safe_Browsing) [2](http://kb.mozillazine.org/Safe_browsing) [3](https://support.mozilla.org/en-US/kb/how-does-phishing-and-malware-protection-work) [4](http://forums.mozillazine.org/viewtopic.php?f=39&t=2711237&p=12896849#p12896849) ]
 * Enable blocking reported attack sites [ [1](http://kb.mozillazine.org/Browser.safebrowsing.malware.enabled) ]
-* Disable safe browsing remote lookups for downloaded files. [ [1](https://www.mozilla.org/en-US/firefox/39.0/releasenotes/) [2](https://wiki.mozilla.org/Security/Application_Reputation) ]
+* Disable querying Google Application Reputation database for downloaded binary files [ [1](https://www.mozilla.org/en-US/firefox/39.0/releasenotes/) [2](https://wiki.mozilla.org/Security/Application_Reputation) ]
 * Disable Pocket [ [1](https://support.mozilla.org/en-US/kb/save-web-pages-later-pocket-firefox) [2](https://github.com/pyllyukko/user.js/issues/143) ]
 
 ### Automatic connections
@@ -266,6 +270,8 @@ Enable and configure private browsing mode, don't store information locally duri
 * Disable form autofill, don't save information entered in web page forms and the Search Bar
 * Cookies expires at the end of the session (when the browser closes) [ [1](http://kb.mozillazine.org/Network.cookie.lifetimePolicy#2) ]
 * Require manual intervention to autofill known username/passwords sign-in forms [ [1](http://kb.mozillazine.org/Signon.autofillForms) [2](https://www.torproject.org/projects/torbrowser/design/#identifier-linkability) ]
+* When username/password autofill is enabled, still disable it on non-HTTPS sites [ [1](https://hg.mozilla.org/integration/mozilla-inbound/rev/f0d146fe7317) ]
+* Show in-content login form warning UI for insecure login fields [ [1](https://hg.mozilla.org/integration/mozilla-inbound/rev/f0d146fe7317) ]
 * Disable the password manager for pages with autocomplete=off [ [1](https://bugzilla.mozilla.org/show_bug.cgi?id=956906) ]
 * Delete Search and Form History
 * Clear SSL Form Session Data [ [1](http://kb.mozillazine.org/Browser.sessionstore.privacy_level#2) ]
@@ -280,6 +286,7 @@ Improve visibility of security-related elements, mitigate shoulder-surfing
 * Disable Downloading on Desktop
 * Always ask the user where to download [ [1](https://developer.mozilla.org/en/Download_Manager_preferences (obsolete)) ]
 * Disable the "new tab page" feature and show a blank tab instead [ [1](https://wiki.mozilla.org/Privacy/Reviews/New_Tab) [2](https://support.mozilla.org/en-US/kb/new-tab-page-show-hide-and-customize-top-sites#w_how-do-i-turn-the-new-tab-page-off) ]
+* Disable new tab tile ads & preload [ [1](http://www.thewindowsclub.com/disable-remove-ad-tiles-from-firefox) [2](http://forums.mozillazine.org/viewtopic.php?p=13876331#p13876331) [3](https://wiki.mozilla.org/Tiles/Technical_Documentation#Ping) [4](https://gecko.readthedocs.org/en/latest/browser/browser/DirectoryLinksProvider.html#browser-newtabpage-directory-source) [5](https://gecko.readthedocs.org/en/latest/browser/browser/DirectoryLinksProvider.html#browser-newtabpage-directory-ping) ]
 * Enable Auto Notification of Outdated Plugins [ [1](https://wiki.mozilla.org/Firefox3.6/Plugin_Update_Awareness_Security_Review) ]
 * Enable Information Bar for Outdated Plugins [ [1](http://forums.mozillazine.org/viewtopic.php?f=8&t=2490287) ]
 * Enable IDN Show Punycode [ [1](http://kb.mozillazine.org/Network.IDN_show_punycode) [2](https://www.xudongz.com/blog/2017/idn-phishing/) ]

--- a/README.md
+++ b/README.md
@@ -128,28 +128,30 @@ it also makes experimenting with different settings easier.
 
 HTML5 / [APIs](https://wiki.mozilla.org/WebAPI) / [DOM](https://en.wikipedia.org/wiki/Document_Object_Model) related settings. Mozilla is keen to implement every new HTML5 feature, which have had unforeseen security or privacy implications. This section disables many of those new and yet to be proven technologies.
 * Disable Service Workers [ [1](https://developer.mozilla.org/en-US/docs/Web/API/Worker) [2](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorker_API) [3](https://wiki.mozilla.org/Firefox/Push_Notifications#Service_Workers) ]
+* Disable Web Workers [ [1](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers) [2](https://www.w3schools.com/html/html5_webworkers.asp) ]
 * Disable web notifications [ [1](https://support.mozilla.org/t5/Firefox/I-can-t-find-Firefox-menu-I-m-trying-to-opt-out-of-Web-Push-and/m-p/1317495#M1006501) ]
+* Disable DOM timing API [ [1](https://wiki.mozilla.org/Security/Reviews/Firefox/NavigationTimingAPI) ]
 * Make sure the User Timing API does not provide a new high resolution timestamp [ [1](https://trac.torproject.org/projects/tor/ticket/16336) ]
 * Disable Web Audio API [ [1](https://bugzilla.mozilla.org/show_bug.cgi?id=1288359) ]
 * Disable Location-Aware Browsing (geolocation) [ [1](https://www.mozilla.org/en-US/firefox/geolocation/) ]
 * When geolocation is enabled, use Mozilla geolocation service instead of Google [ [1](https://bugzilla.mozilla.org/show_bug.cgi?id=689252) ]
 * When geolocation is enabled, don't log geolocation requests to the console
 * Disable raw TCP socket support (mozTCPSocket) [ [1](https://trac.torproject.org/projects/tor/ticket/18863) [2](https://www.mozilla.org/en-US/security/advisories/mfsa2015-97/) [3](https://developer.mozilla.org/docs/Mozilla/B2G_OS/API/TCPSocket) ]
-* Whether JS can get information about the network/browser connection
+* Disable leaking network/browser connection information via Javascript
 * Disable WebRTC entirely to prevent leaking internal IP addresses (Firefox < 42)
 * Don't reveal your internal IP when WebRTC is enabled (Firefox >= 42) [ [1](https://wiki.mozilla.org/Media/WebRTC/Privacy) [2](https://github.com/beefproject/beef/wiki/Module%3A-Get-Internal-IP-WebRTC) ]
 * Disable WebRTC getUserMedia, screen sharing, audio capture, video capture [ [1](https://wiki.mozilla.org/Media/getUserMedia) [2](https://blog.mozilla.org/futurereleases/2013/01/12/capture-local-camera-and-microphone-streams-with-getusermedia-now-enabled-in-firefox/) [3](https://developer.mozilla.org/en-US/docs/Web/API/Navigator) ]
 * Disable battery API (Firefox < 52) [ [1](https://developer.mozilla.org/en-US/docs/Web/API/BatteryManager) [2](https://bugzilla.mozilla.org/show_bug.cgi?id=1313580) ]
 * Disable telephony API [ [1](https://wiki.mozilla.org/WebAPI/Security/WebTelephony) ]
-* Disable DOM timing API [ [1](https://wiki.mozilla.org/Security/Reviews/Firefox/NavigationTimingAPI) ]
 * Disable "beacon" asynchronous HTTP transfers (used for analytics) [ [1](https://developer.mozilla.org/en-US/docs/Web/API/navigator.sendBeacon) ]
-* Disable clipboard manipulation via JavaScript [ [1](https://developer.mozilla.org/en-US/docs/Mozilla/Preferences/Preference_reference/dom.event.clipboardevents.enabled) ]
+* Disable clipboard event detection (onCut/onCopy/onPaste) via Javascript [ [1](https://developer.mozilla.org/en-US/docs/Mozilla/Preferences/Preference_reference/dom.event.clipboardevents.enabled) ]
+* Disable "copy to clipboard" functionality via Javascript (Firefox >= 41)
 * Disable speech recognition [ [1](https://dvcs.w3.org/hg/speech-api/raw-file/tip/speechapi.html) [2](https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognition) [3](https://wiki.mozilla.org/HTML5_Speech_API) ]
 * Disable speech synthesis [ [1](https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesis) ]
 * Disable sensor API [ [1](https://wiki.mozilla.org/Sensor_API) ]
 * Disable pinging URIs specified in HTML <a> ping= attributes [ [1](http://kb.mozillazine.org/Browser.send_pings) ]
 * When browser pings are enabled, only allow pinging the same host as the origin page [ [1](http://kb.mozillazine.org/Browser.send_pings.require_same_host) ]
-* Disable gamepad input [ [1](https://www.w3.org/TR/gamepad/) ]
+* Disable gamepad API to prevent USB device enumeration [ [1](https://www.w3.org/TR/gamepad/) [2](https://trac.torproject.org/projects/tor/ticket/13023) ]
 * Disable virtual reality devices APIs [ [1](https://developer.mozilla.org/en-US/Firefox/Releases/36#Interfaces.2FAPIs.2FDOM) [2](https://developer.mozilla.org/en-US/docs/Web/API/WebVR_API) ]
 * Disable vibrator API
 * Disable webGL [ [1](https://en.wikipedia.org/wiki/WebGL) [2](https://www.contextis.com/resources/blog/webgl-new-dimension-browser-exploitation/) ]
@@ -181,6 +183,7 @@ Settings that do not belong to other sections or are user specific preferences.
 * Disable Displaying Javascript in History URLs [ [1](http://kb.mozillazine.org/Browser.urlbar.filter.javascript) ]
 * Disable asm.js [ [1](http://asmjs.org/) [2](https://www.mozilla.org/en-US/security/advisories/mfsa2015-29/) [3](https://www.mozilla.org/en-US/security/advisories/mfsa2015-50/) [4](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-2712) ]
 * Disable SVG in OpenType fonts [ [1](https://wiki.mozilla.org/SVGOpenTypeFonts) [2](https://github.com/iSECPartners/publications/tree/master/reports/Tor%20Browser%20Bundle) ]
+* Disable in-content SVG rendering (Firefox >= 53)
 * Disable video stats to reduce fingerprinting threat [ [1](https://bugzilla.mozilla.org/show_bug.cgi?id=654550) [2](https://github.com/pyllyukko/user.js/issues/9#issuecomment-100468785) [3](https://github.com/pyllyukko/user.js/issues/9#issuecomment-148922065) ]
 * Don't reveal build ID
 * Prevent font fingerprinting [ [1](https://browserleaks.com/fonts) [2](https://github.com/pyllyukko/user.js/issues/120) ]
@@ -221,6 +224,7 @@ Disable Firefox integrated metrics/reporting/experiments, disable potentially in
 * Disable collection/sending of the health report (healthreport.sqlite*) [ [1](https://support.mozilla.org/en-US/kb/firefox-health-report-understand-your-browser-perf) [2](https://gecko.readthedocs.org/en/latest/toolkit/components/telemetry/telemetry/preferences.html) ]
 * Disable Heartbeat  (Mozilla user rating telemetry) [ [1](https://wiki.mozilla.org/Advocacy/heartbeat) [2](https://trac.torproject.org/projects/tor/ticket/19047) [3](https://trac.torproject.org/projects/tor/ticket/18738) ]
 * Disable Firefox Hello metrics collection [ [1](https://groups.google.com/d/topic/mozilla.dev.platform/nyVkCx-_sFw/discussion) ]
+* Enforce checking for Firefox updates
 * Enable blocking reported web forgeries [ [1](https://wiki.mozilla.org/Security/Safe_Browsing) [2](http://kb.mozillazine.org/Safe_browsing) [3](https://support.mozilla.org/en-US/kb/how-does-phishing-and-malware-protection-work) [4](http://forums.mozillazine.org/viewtopic.php?f=39&t=2711237&p=12896849#p12896849) ]
 * Enable blocking reported attack sites [ [1](http://kb.mozillazine.org/Browser.safebrowsing.malware.enabled) ]
 * Disable querying Google Application Reputation database for downloaded binary files [ [1](https://www.mozilla.org/en-US/firefox/39.0/releasenotes/) [2](https://wiki.mozilla.org/Security/Application_Reputation) ]
@@ -246,7 +250,7 @@ Prevents the browser from [auto-connecting](https://support.mozilla.org/en-US/kb
 HTTP protocol related entries. This affects cookies, the user agent, referer and others.
 * Disallow NTLMv1 [ [1](https://bugzilla.mozilla.org/show_bug.cgi?id=828183) ]
 * Enable CSP 1.1 script-nonce directive support [ [1](https://bugzilla.mozilla.org/show_bug.cgi?id=855326) ]
-* Enable Content Security Policy
+* Enable Content Security Policy (CSP) [ [1](https://developer.mozilla.org/en-US/docs/Web/Security/CSP/Introducing_Content_Security_Policy) [2](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) ]
 * Enable Subresource Integrity [ [1](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) [2](https://wiki.mozilla.org/Security/Subresource_Integrity) ]
 * Send a referer header with the target URI as the source [ [1](https://bugzilla.mozilla.org/show_bug.cgi?id=822869) [2](https://github.com/pyllyukko/user.js/issues/227) ]
 * Accept Only 1st Party Cookies [ [1](http://kb.mozillazine.org/Network.cookie.cookieBehavior#1) ]
@@ -277,6 +281,8 @@ Enable and configure private browsing mode, don't store information locally duri
 * Clear SSL Form Session Data [ [1](http://kb.mozillazine.org/Browser.sessionstore.privacy_level#2) ]
 * Delete temporary files on exit [ [1](https://bugzilla.mozilla.org/show_bug.cgi?id=238789) ]
 * Do not create screenshots of visited pages (relates to the "new tab page" feature) [ [1](https://support.mozilla.org/en-US/questions/973320) [2](https://developer.mozilla.org/en-US/docs/Mozilla/Preferences/Preference_reference/browser.pagethumbnails.capturing_disabled) ]
+* Don't fetch and permanently store bookmarks favicons to $profile_dir/shortcutCache
+* Disable bookmarks backups (default: 15) [ [1](http://kb.mozillazine.org/Browser.bookmarks.max_backups) ]
 
 ### UI related
 
@@ -289,7 +295,7 @@ Improve visibility of security-related elements, mitigate shoulder-surfing
 * Disable new tab tile ads & preload [ [1](http://www.thewindowsclub.com/disable-remove-ad-tiles-from-firefox) [2](http://forums.mozillazine.org/viewtopic.php?p=13876331#p13876331) [3](https://wiki.mozilla.org/Tiles/Technical_Documentation#Ping) [4](https://gecko.readthedocs.org/en/latest/browser/browser/DirectoryLinksProvider.html#browser-newtabpage-directory-source) [5](https://gecko.readthedocs.org/en/latest/browser/browser/DirectoryLinksProvider.html#browser-newtabpage-directory-ping) ]
 * Enable Auto Notification of Outdated Plugins [ [1](https://wiki.mozilla.org/Firefox3.6/Plugin_Update_Awareness_Security_Review) ]
 * Enable Information Bar for Outdated Plugins [ [1](http://forums.mozillazine.org/viewtopic.php?f=8&t=2490287) ]
-* Enable IDN Show Punycode [ [1](http://kb.mozillazine.org/Network.IDN_show_punycode) [2](https://www.xudongz.com/blog/2017/idn-phishing/) ]
+* Force Punycode for Internationalized Domain Names [ [1](http://kb.mozillazine.org/Network.IDN_show_punycode) [2](https://www.xudongz.com/blog/2017/idn-phishing/) [3](https://wiki.mozilla.org/IDN_Display_Algorithm) [4](https://en.wikipedia.org/wiki/IDN_homograph_attack) [5](https://www.mozilla.org/en-US/security/advisories/mfsa2017-02/) ]
 * Disable inline autocomplete in URL bar [ [1](http://kb.mozillazine.org/Inline_autocomplete) ]
 * Don't suggest any URLs while typing at the address bar [ [1](https://www.labnol.org/software/browsers/prevent-firefox-showing-bookmarks-address-location-bar/3636/) [2](http://kb.mozillazine.org/Browser.urlbar.maxRichResults) ]
 * Disable CSS :visited selectors [ [1](https://blog.mozilla.org/security/2010/03/31/plugging-the-css-history-leak/) [2](https://dbaron.org/mozilla/visited-privacy) ]
@@ -386,9 +392,12 @@ Hardening your often implies a trade-off with ease-of-use and comes with reduced
 * Disabling ServiceWorkers breaks functionality on some sites (Google Street View...)
 * Disabling DOM storage is known to cause`TypeError: localStorage is null` errors
 * Disabling WebRTC breaks peer-to-peer file sharing tools (reep.io ...)
+* Disabling clipboard operations will break legitimate JS-based "copy to clipboard" functionality
 * IndexedDB could be used for tracking purposes, but is required for some add-ons to work (notably uBlock), so is left enabled
+* Disabling SVG support breaks many UI elements on many sites
 * Containers are not available in Private Browsing mode
 * Firefox Hello requires setting `media.peerconnection.enabled` and `media.getusermedia.screensharing.enabled` to true, `security.OCSP.require` to false to work.
+* Fully automatic updates are disabled and left to package management systems on Linux. Windows users may want to change this setting.
 * Do No Track must be enabled manually
 * Spoofing referers breaks functionality on websites relying on authentic referer headers
 * Spoofing referers breaks visualisation of 3rd-party sites on the Lightbeam addon
@@ -399,6 +408,7 @@ Hardening your often implies a trade-off with ease-of-use and comes with reduced
 * Private browsing breaks Kerberos authentication
 * Disables "Containers" functionality (see below)
 * Installing user.js will **remove your saved passwords** (https://github.com/pyllyukko/user.js/issues/27)
+* Bookmarks will only be shown with a generic icon
 * OCSP leaks your IP and domains you visit to the CA when OCSP Stapling is not available on visited host
 * OCSP is vulnerable to replay attacks when nonce is not configured on the OCSP responder
 * OCSP adds latency (performance)

--- a/ignore.list
+++ b/ignore.list
@@ -80,10 +80,15 @@
 "media.peerconnection.identity.timeout"
 "media.peerconnection.turn.disable"
 
-// Don't disable full screen API/support
+// Don't disable full screen API/support (relaxed) (usability)
 "full-screen-api.enabled"
 
 // Don't change fine VR API options, VR support is disabled via master switch
 "dom.vr.oculus.enabled"
 "dom.vr.osvr.enabled" // (Firefox >= 49)
 "dom.vr.openvr.enabled" // (Firefox >=51)
+
+// Don't change disk cache settings, disk cache is disabled
+"browser.cache.disk.capacity"
+"browser.cache.disk.smart_size.enabled"
+"browser.cache.disk.smart_size.first_run"

--- a/ignore.list
+++ b/ignore.list
@@ -150,7 +150,7 @@
 "browser.tabs.warnOnCloseOtherTabs"
 "browser.tabs.warnOnOpen"
 
-// Don't change redirection limit, default is 20 redirects
+// Don't change redirection limit, default is 20 redirects (Network)
 "network.http.redirection-limit"
 
 // don't change backspace key action (0 = previous page, 1 = scroll up, 2 = do nothing) (UI)
@@ -174,3 +174,12 @@
 
 // Don't change behaviour for switching to new tabs when they are opened (UI)
 "browser.tabs.loadInBackground"
+
+// Don't change default setting for console warnings about non-e10s-compatible addons (Development)
+"dom.ipc.shims.enabledWarnings"
+
+// Don't change sandboxing level settings
+// https://wiki.mozilla.org/Sandbox
+"security.sandbox.content.level"
+"dom.ipc.plugins.sandbox-level.default"
+"dom.ipc.plugins.sandbox-level.flash"

--- a/ignore.list
+++ b/ignore.list
@@ -2,7 +2,6 @@
 // Preference names must use double quotes
 
 // Don't touch Firefox social API preferences, fully opt-in, WONTFIX
-"toolkit.telemetry.unifiedIsOptIn"
 "social.whitelist"
 "social.toast-notifications.enabled"
 "social.shareDirectory"
@@ -114,3 +113,28 @@
 "dom.disable_window_status_change"
 "dom.allow_scripts_to_close_windows"
 "dom.disable_window_status_change"
+
+// Show "View source" in a separate window instead of tab (UI) WONTFIX
+"view_source.tab"
+
+// Firefox accounts/WebChannels settings WONTFIX
+// https://dxr.mozilla.org/mozilla-beta/source/services/fxaccounts/FxAccountsConfig.jsm
+// https://mozilla-services.readthedocs.io/en/latest/howtos/run-fxa.html
+"webchannel.allowObject.urlWhitelist"
+
+// Don't change slow startup detection (UI) WONTFIX
+"browser.slowStartup.notificationDisabled"
+"browser.slowStartup.maxSamples"
+"browser.slowStartup.samples"
+
+// Don't hide "know your rights" infobar (UI) WONTFIX
+"browser.rights.3.shown"
+
+// Don't change browser startup/homepage/welcome page settings (UI) WONTFIX
+"browser.startup.homepage_override.mstone"
+"startup.homepage_welcome_url"
+"startup.homepage_welcome_url.additional"
+"startup.homepage_override_url" // what's new page after updates
+"browser.laterrun.enabled"
+"browser.startup.page"
+

--- a/ignore.list
+++ b/ignore.list
@@ -20,3 +20,27 @@
 
 // Deprecated Do Not Track setting, Firefox <36, https://hg.mozilla.org/mozilla-central/rev/9a16137bc7b4
 "privacy.donottrackheader.value"
+
+// Don't alter "Warn me about unwanted and uncommon software" options, safebrowsing.downloads.enabled master switch is off
+"browser.safebrowsing.downloads.remote.block_potentially_unwanted" // (FF48+)
+"browser.safebrowsing.downloads.remote.block_uncommon" // (FF48+)
+"browser.safebrowsing.downloads.remote.block_dangerous" // (FF49+)
+"browser.safebrowsing.downloads.remote.block_dangerous_host" // (FF49+)
+// Don't alter URL for binary downloads check
+"browser.safebrowsing.downloads.remote.url"
+
+// Don't alter update URLs for safebrowsing data, WONTFIX
+"browser.safebrowsing.provider.google.updateURL" // update google lists
+"browser.safebrowsing.provider.google.gethashURL" // list hash check
+"browser.safebrowsing.provider.google4.updateURL" // (FF50+)
+"browser.safebrowsing.provider.google4.gethashURL" // (FF50+)
+
+// Don't alter Mozilla safebrowsing/tracing protection download URLs, WONTFIX
+"browser.safebrowsing.provider.mozilla.gethashURL" // resolves hash conflicts
+"browser.safebrowsing.provider.mozilla.updateURL" // update FF lists
+
+// Do NOT select "clear passwords" in clear private data dialog (relaxed) (usability)
+"privacy.cpd.passwords"
+
+// Do NOT select "site settings" in clear private data dialog (relaxed) (usability)
+"privacy.clearOnShutdown.siteSettings"

--- a/ignore.list
+++ b/ignore.list
@@ -10,7 +10,7 @@
 "social.share.activationPanelEnabled"
 "social.enabled"
 
-// Don't disable Firefox Sync, fully opt-in, WONTFIX
+// Don't disable Firefox Sync, fully opt-in
 // https://wiki.mozilla.org/Services/Sync
 "services.sync.enabled"
 
@@ -20,7 +20,7 @@
 // Deprecated Do Not Track setting, Firefox <36, https://hg.mozilla.org/mozilla-central/rev/9a16137bc7b4
 "privacy.donottrackheader.value"
 
-// Don't alter "Warn me about unwanted and uncommon software" options, safebrowsing.downloads.enabled master switch is off
+// Don't alter safebrowsing.downloads.* options, safebrowsing.downloads.enabled master switch is off
 "browser.safebrowsing.downloads.remote.block_potentially_unwanted" // (FF48+)
 "browser.safebrowsing.downloads.remote.block_uncommon" // (FF48+)
 "browser.safebrowsing.downloads.remote.block_dangerous" // (FF49+)
@@ -28,13 +28,20 @@
 // Don't alter URL for binary downloads check
 "browser.safebrowsing.downloads.remote.url"
 
-// Don't alter update URLs for safebrowsing data, WONTFIX
+// Don't alter Mozilla/Google update URLs for safebrowsing data, safebrowsing should stay enabled
 "browser.safebrowsing.provider.google.updateURL" // update google lists
 "browser.safebrowsing.provider.google.gethashURL" // list hash check
 "browser.safebrowsing.provider.google4.updateURL" // (FF50+)
 "browser.safebrowsing.provider.google4.gethashURL" // (FF50+)
-
-// Don't alter Mozilla safebrowsing/tracing protection download URLs, WONTFIX
+"browser.safebrowsing.gethashURL"
+"browser.safebrowsing.malware.reportURL"
+"browser.safebrowsing.provider.google.appRepURL"
+"browser.safebrowsing.reportErrorURL"
+"browser.safebrowsing.reportGenericURL"
+"browser.safebrowsing.reportMalwareErrorURL"
+"browser.safebrowsing.reportMalwareURL"
+"browser.safebrowsing.reportURL"
+"browser.safebrowsing.updateURL"
 "browser.safebrowsing.provider.mozilla.gethashURL" // resolves hash conflicts
 "browser.safebrowsing.provider.mozilla.updateURL" // update FF lists
 
@@ -114,23 +121,23 @@
 "dom.allow_scripts_to_close_windows"
 "dom.disable_window_status_change"
 
-// Show "View source" in a separate window instead of tab (UI) WONTFIX
+// Show "View source" in a separate window instead of tab (UI)
 "view_source.tab"
 
-// Firefox accounts/WebChannels settings WONTFIX
+// Don't change Firefox accounts/WebChannels settings
 // https://dxr.mozilla.org/mozilla-beta/source/services/fxaccounts/FxAccountsConfig.jsm
 // https://mozilla-services.readthedocs.io/en/latest/howtos/run-fxa.html
 "webchannel.allowObject.urlWhitelist"
 
-// Don't change slow startup detection (UI) WONTFIX
+// Don't change slow startup detection (UI)
 "browser.slowStartup.notificationDisabled"
 "browser.slowStartup.maxSamples"
 "browser.slowStartup.samples"
 
-// Don't hide "know your rights" infobar (UI) WONTFIX
+// Don't hide "know your rights" infobar (UI)
 "browser.rights.3.shown"
 
-// Don't change browser startup/homepage/welcome page settings (UI) WONTFIX
+// Don't change browser startup/homepage/welcome page settings (UI)
 "browser.startup.homepage_override.mstone"
 "startup.homepage_welcome_url"
 "startup.homepage_welcome_url.additional"
@@ -138,7 +145,7 @@
 "browser.laterrun.enabled"
 "browser.startup.page"
 
-// Don't change tab-related warnings settings (UI) WONTFIX
+// Don't change tab-related warnings settings (UI)
 "browser.tabs.warnOnClose"
 "browser.tabs.warnOnCloseOtherTabs"
 "browser.tabs.warnOnOpen"

--- a/ignore.list
+++ b/ignore.list
@@ -153,4 +153,24 @@
 // Don't change redirection limit, default is 20 redirects
 "network.http.redirection-limit"
 
+// don't change backspace key action (0 = previous page, 1 = scroll up, 2 = do nothing) (UI)
+"browser.backspace_action"
 
+// Don't change ctrl-tab previews options (UI)
+"browser.ctrlTab.previews"
+
+// Don't change spellchecking controls options (UI)
+"layout.spellcheckDefault"
+
+// Don't change URL bar selection behaviour (UI)
+"browser.urlbar.clickSelectsAll"
+"browser.urlbar.doubleClickSelectsAll"
+
+// Don't change settings for new tab position in tab bar (UI)
+"browser.tabs.insertRelatedAfterCurrent"
+
+// Don't change setting for switching back to parent tab on tab close (UI)
+"browser.tabs.selectOwnerOnClose"
+
+// Don't change behaviour for switching to new tabs when they are opened (UI)
+"browser.tabs.loadInBackground"

--- a/ignore.list
+++ b/ignore.list
@@ -143,3 +143,7 @@
 "browser.tabs.warnOnCloseOtherTabs"
 "browser.tabs.warnOnOpen"
 
+// Don't change redirection limit, default is 20 redirects
+"network.http.redirection-limit"
+
+

--- a/ignore.list
+++ b/ignore.list
@@ -44,3 +44,46 @@
 
 // Do NOT select "site settings" in clear private data dialog (relaxed) (usability)
 "privacy.clearOnShutdown.siteSettings"
+
+// Don't disable featured extensions list in add-ons tab
+"extensions.webservice.discoverURL"
+
+// Don't change fine telemetry options, telemetry is disabled
+"toolkit.telemetry.unifiedIsOptIn"
+"toolkit.telemetry.server"
+"toolkit.telemetry.archive.enabled"
+"toolkit.telemetry.cachedClientID"
+
+// Don't disable local about:healthreport page, remote healthreport submission is disabled. locale/css+js+json for this page are requested from mozilla
+"datareporting.healthreport.about.reportUrl"
+
+// Don't change New Tab page/tiles specific options, new tab page is disabled
+"browser.newtabpage.introShown"
+
+// Don't change per-tab back/forward history retention (default: 50 URLs). Can be queried via JavaScript (relaxed) (usability)
+"browser.sessionhistory.max_entries"
+
+// Don't change Windows-specific taskbar/jumplist options (UI)
+"browser.taskbar.lists.enabled"
+"browser.taskbar.lists.frequent.enabled"
+"browser.taskbar.lists.recent.enabled"
+"browser.taskbar.lists.tasks.enabled"
+"browser.taskbar.previews.enable"
+
+// Don't disable intermediate certificate caching, breaks many sites, fingerprint via intermediate CA caching can be prevented by blocking cross-site requests. (relaxed) (compatibility)
+"security.nocertdb"
+
+// Don't change supported PeerConnection/WebRTC functionality, WebRTC is disabled via master switch.
+"media.peerconnection.use_document_iceservers"
+"media.peerconnection.video.enabled"
+"media.peerconnection.identity.enabled"
+"media.peerconnection.identity.timeout"
+"media.peerconnection.turn.disable"
+
+// Don't disable full screen API/support
+"full-screen-api.enabled"
+
+// Don't change fine VR API options, VR support is disabled via master switch
+"dom.vr.oculus.enabled"
+"dom.vr.osvr.enabled" // (Firefox >= 49)
+"dom.vr.openvr.enabled" // (Firefox >=51)

--- a/ignore.list
+++ b/ignore.list
@@ -92,3 +92,25 @@
 "browser.cache.disk.capacity"
 "browser.cache.disk.smart_size.enabled"
 "browser.cache.disk.smart_size.first_run"
+
+// Don't alter default fonts (UI)
+"font.name.monospace.x-unicode"
+"font.name.monospace.x-western"
+"font.name.sans-serif.x-unicode"
+"font.name.sans-serif.x-western"
+"font.name.serif.x-unicode"
+"font.name.serif.x-western"
+
+// Don't touch about:config warning message (UI)
+"general.warnOnAboutConfig"
+
+// Don't try to prevent javascript popup window manipulation (size/toolbars...) (UI)
+"dom.disable_window_flip" // window z-order
+"dom.disable_window_move_resize"
+"dom.disable_window_open_feature.close"
+"dom.disable_window_open_feature.minimizable"
+"dom.disable_window_open_feature.personalbar" //bookmarks toolbar
+"dom.disable_window_open_feature.titlebar"
+"dom.disable_window_status_change"
+"dom.allow_scripts_to_close_windows"
+"dom.disable_window_status_change"

--- a/ignore.list
+++ b/ignore.list
@@ -138,3 +138,8 @@
 "browser.laterrun.enabled"
 "browser.startup.page"
 
+// Don't change tab-related warnings settings (UI) WONTFIX
+"browser.tabs.warnOnClose"
+"browser.tabs.warnOnCloseOtherTabs"
+"browser.tabs.warnOnOpen"
+

--- a/user.js
+++ b/user.js
@@ -138,9 +138,6 @@ user_pref("dom.gamepad.enabled",				false);
 // https://developer.mozilla.org/en-US/Firefox/Releases/36#Interfaces.2FAPIs.2FDOM
 // https://developer.mozilla.org/en-US/docs/Web/API/WebVR_API
 user_pref("dom.vr.enabled",					false);
-user_pref("dom.vr.oculus.enabled",          false);
-user_pref("dom.vr.osvr.enabled",            false); // (Firefox >= 49)
-user_pref("dom.vr.openvr.enabled",          false); // (Firefox >=51)
 
 // PREF: Disable vibrator API
 user_pref("dom.vibrator.enabled",           false);
@@ -446,18 +443,6 @@ user_pref("pdfjs.disabled",					true);
 user_pref("datareporting.healthreport.uploadEnabled",		false);
 user_pref("datareporting.healthreport.service.enabled",		false);
 user_pref("datareporting.policy.dataSubmissionEnabled",		false);
-
-// PREF: Disable new tab tile ads & preload
-// http://www.thewindowsclub.com/disable-remove-ad-tiles-from-firefox
-// http://forums.mozillazine.org/viewtopic.php?p=13876331#p13876331
-// https://wiki.mozilla.org/Tiles/Technical_Documentation#Ping
-// https://gecko.readthedocs.org/en/latest/browser/browser/DirectoryLinksProvider.html#browser-newtabpage-directory-source
-// https://gecko.readthedocs.org/en/latest/browser/browser/DirectoryLinksProvider.html#browser-newtabpage-directory-ping
-// TODO: deprecated? not in DXR, some dead links
-user_pref("browser.newtabpage.enhanced",			false);
-user_pref("browser.newtab.preload",				false);
-user_pref("browser.newtabpage.directory.ping",			"");
-user_pref("browser.newtabpage.directory.source",		"data:text/plain,{}");
 
 // PREF: Disable Heartbeat  (Mozilla user rating telemetry)
 // https://wiki.mozilla.org/Advocacy/heartbeat
@@ -779,6 +764,18 @@ user_pref("browser.download.useDownloadDir",			false);
 // https://support.mozilla.org/en-US/kb/new-tab-page-show-hide-and-customize-top-sites#w_how-do-i-turn-the-new-tab-page-off
 user_pref("browser.newtabpage.enabled",				false);
 user_pref("browser.newtab.url",					"about:blank");
+
+// PREF: Disable new tab tile ads & preload
+// http://www.thewindowsclub.com/disable-remove-ad-tiles-from-firefox
+// http://forums.mozillazine.org/viewtopic.php?p=13876331#p13876331
+// https://wiki.mozilla.org/Tiles/Technical_Documentation#Ping
+// https://gecko.readthedocs.org/en/latest/browser/browser/DirectoryLinksProvider.html#browser-newtabpage-directory-source
+// https://gecko.readthedocs.org/en/latest/browser/browser/DirectoryLinksProvider.html#browser-newtabpage-directory-ping
+// TODO: deprecated? not in DXR, some dead links
+user_pref("browser.newtabpage.enhanced",			false);
+user_pref("browser.newtab.preload",				false);
+user_pref("browser.newtabpage.directory.ping",			"");
+user_pref("browser.newtabpage.directory.source",		"data:text/plain,{}");
 
 // PREF: Enable Auto Notification of Outdated Plugins
 // https://wiki.mozilla.org/Firefox3.6/Plugin_Update_Awareness_Security_Review

--- a/user.js
+++ b/user.js
@@ -25,6 +25,10 @@ user_pref("dom.workers.enabled",false)
 // https://support.mozilla.org/t5/Firefox/I-can-t-find-Firefox-menu-I-m-trying-to-opt-out-of-Web-Push-and/m-p/1317495#M1006501
 user_pref("dom.webnotifications.enabled",			false);
 
+// PREF: Disable DOM timing API
+// https://wiki.mozilla.org/Security/Reviews/Firefox/NavigationTimingAPI
+user_pref("dom.enable_performance",				false);
+
 // PREF: Make sure the User Timing API does not provide a new high resolution timestamp
 // https://trac.torproject.org/projects/tor/ticket/16336
 user_pref("dom.enable_user_timing",				false);
@@ -89,10 +93,6 @@ user_pref("dom.battery.enabled",				false);
 // PREF: Disable telephony API
 // https://wiki.mozilla.org/WebAPI/Security/WebTelephony
 user_pref("dom.telephony.enabled",				false);
-
-// PREF: Disable DOM timing API
-// https://wiki.mozilla.org/Security/Reviews/Firefox/NavigationTimingAPI
-user_pref("dom.enable_performance",				false);
 
 // PREF: Disable "beacon" asynchronous HTTP transfers (used for analytics)
 // https://developer.mozilla.org/en-US/docs/Web/API/navigator.sendBeacon

--- a/user.js
+++ b/user.js
@@ -750,6 +750,10 @@ user_pref("browser.pagethumbnails.capturing_disabled",		true);
 // Use a generic icon instead
 user_pref("browser.shell.shortcutFavicons",					false);
 
+// PREF: Disable bookmarks backups (default: 15)
+// http://kb.mozillazine.org/Browser.bookmarks.max_backups
+user_pref("browser.bookmarks.max_backups", 0);
+
 /*******************************************************************************
  * SECTION: UI related                                                         *
  *******************************************************************************/

--- a/user.js
+++ b/user.js
@@ -16,6 +16,11 @@
 // CVE-2016-5259, CVE-2016-2812, CVE-2016-1949, CVE-2016-5287 (fixed)
 user_pref("dom.serviceWorkers.enabled",				false);
 
+// PREF: Disable Web Workers
+// https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers
+// https://www.w3schools.com/html/html5_webworkers.asp
+user_pref("dom.workers.enabled",false)
+
 // PREF: Disable web notifications
 // https://support.mozilla.org/t5/Firefox/I-can-t-find-Firefox-menu-I-m-trying-to-opt-out-of-Web-Push-and/m-p/1317495#M1006501
 user_pref("dom.webnotifications.enabled",			false);

--- a/user.js
+++ b/user.js
@@ -32,6 +32,11 @@ user_pref("dom.webaudio.enabled",				false);
 // https://www.mozilla.org/en-US/firefox/geolocation/
 user_pref("geo.enabled",					false);
 
+// PREF: when geolocation is enabled, use Mozilla geolocation service instead of Google
+user_pref("geo.wifi.uri", "https://location.services.mozilla.com/v1/geolocate?key=test");
+// PREF: when geolocation is enabled, don't log geolocation requests to the console
+user_pref("geo.wifi.logging.enabled", false);
+
 // PREF: Disable raw TCP socket support (mozTCPSocket)
 // https://trac.torproject.org/projects/tor/ticket/18863
 // https://www.mozilla.org/en-US/security/advisories/mfsa2015-97/
@@ -128,9 +133,16 @@ user_pref("browser.send_pings.require_same_host",		true);
 // https://www.w3.org/TR/gamepad/
 user_pref("dom.gamepad.enabled",				false);
 
-// PREF: Disable virtual reality devices
+// PREF: Disable virtual reality devices APIs
 // https://developer.mozilla.org/en-US/Firefox/Releases/36#Interfaces.2FAPIs.2FDOM
+// https://developer.mozilla.org/en-US/docs/Web/API/WebVR_API
 user_pref("dom.vr.enabled",					false);
+user_pref("dom.vr.oculus.enabled",          false);
+user_pref("dom.vr.osvr.enabled",            false); // (Firefox >= 49)
+user_pref("dom.vr.openvr.enabled",          false); // (Firefox >=51)
+
+// PREF: Disable vibrator API
+user_pref("dom.vibrator.enabled",           false);
 
 // PREF: Disable webGL
 // https://en.wikipedia.org/wiki/WebGL
@@ -206,6 +218,9 @@ user_pref("browser.urlbar.trimURLs",				false);
 // PREF: Don't try to guess domain names when entering an invalid domain name in URL bar
 // http://www-archive.mozilla.org/docs/end-user/domain-guessing.html
 user_pref("browser.fixup.alternate.enabled",			false);
+
+// PREF: When browser.fixup.alternate.enabled is enabled, do not fix URLs containing 'user:password' data
+user_pref("browser.fixup.hide_user_pass", true);
 
 // PREF: Send DNS request through SOCKS when SOCKS proxying is in use
 // https://trac.torproject.org/projects/tor/wiki/doc/TorifyHOWTO/WebBrowsers
@@ -303,6 +318,11 @@ user_pref("dom.ipc.plugins.flash.subprocess.crashreporter.enabled",	false);
 
 // PREF: When Flash crash reports are enabled, don't send the visited URL in the crash report
 user_pref("dom.ipc.plugins.reportCrashURL",			false);
+
+// PREF: When Flash is enabled, download and use Mozilla SWF URIs blocklist
+// https://bugzilla.mozilla.org/show_bug.cgi?id=1237198
+// https://github.com/mozilla-services/shavar-plugin-blocklist
+user_pref("browser.safebrowsing.blockedURIs.enabled", true);
 
 // PREF: Disable Gnome Shell Integration
 user_pref("plugin.state.libgnome-shell-browser-plugin",		0);
@@ -438,9 +458,11 @@ user_pref("browser.newtab.preload",				false);
 user_pref("browser.newtabpage.directory.ping",			"");
 user_pref("browser.newtabpage.directory.source",		"data:text/plain,{}");
 
-// PREF: Disable heartbeat
+// PREF: Disable Heartbeat  (Mozilla user rating telemetry)
 // https://wiki.mozilla.org/Advocacy/heartbeat
 // https://trac.torproject.org/projects/tor/ticket/19047
+// https://trac.torproject.org/projects/tor/ticket/18738
+user_pref("browser.selfsupport.enabled",            false);
 user_pref("browser.selfsupport.url",				"");
 
 // PREF: Disable Firefox Hello (disabled) (Firefox < 49)
@@ -473,10 +495,9 @@ user_pref("browser.safebrowsing.phishing.enabled",		true); // firefox >= 50
 // CIS 2.3.5
 user_pref("browser.safebrowsing.malware.enabled",		true);
 
-// PREF: Disable safe browsing remote lookups for downloaded files.
+// PREF: Disable querying Google Application Reputation database for downloaded binary files
 // https://www.mozilla.org/en-US/firefox/39.0/releasenotes/
 // https://wiki.mozilla.org/Security/Application_Reputation
-// This leaks information to google.
 user_pref("browser.safebrowsing.downloads.remote.enabled",	false);
 
 // PREF: Disable Pocket
@@ -641,7 +662,7 @@ user_pref("privacy.clearOnShutdown.history",			true);
 user_pref("privacy.clearOnShutdown.offlineApps",		true);
 user_pref("privacy.clearOnShutdown.passwords",			true);
 user_pref("privacy.clearOnShutdown.sessions",			true);
-//user_pref("privacy.clearOnShutdown.siteSettings",		false);
+user_pref("privacy.clearOnShutdown.openWindows",		true);
 
 // PREF: Set time range to "Everything" as default in "Clear Recent History"
 user_pref("privacy.sanitize.timeSpan",				0);
@@ -690,6 +711,14 @@ user_pref("network.cookie.lifetimePolicy",			2);
 // http://kb.mozillazine.org/Signon.autofillForms
 // https://www.torproject.org/projects/torbrowser/design/#identifier-linkability
 user_pref("signon.autofillForms",				false);
+
+// PREF: When username/password autofill is enabled, still disable it on non-HTTPS sites
+// https://hg.mozilla.org/integration/mozilla-inbound/rev/f0d146fe7317
+user_pref("signon.autofillForms.http",				false);
+
+// PREF: Show in-content login form warning UI for insecure login fields
+// https://hg.mozilla.org/integration/mozilla-inbound/rev/f0d146fe7317
+user_pref("security.insecure_field_warning.contextual.enabled", true);
 
 // PREF: Disable the password manager for pages with autocomplete=off
 // https://bugzilla.mozilla.org/show_bug.cgi?id=956906

--- a/user.js
+++ b/user.js
@@ -272,6 +272,13 @@ user_pref("javascript.options.asmjs",				false);
 // https://github.com/iSECPartners/publications/tree/master/reports/Tor%20Browser%20Bundle
 user_pref("gfx.font_rendering.opentype_svg.enabled",		false);
 
+// PREF: Disable in-content SVG rendering
+// NOTICE: Disabling SVG support breaks many UI elements on many sites
+// https://bugzilla.mozilla.org/show_bug.cgi?id=1216893
+// https://github.com/iSECPartners/publications/raw/master/reports/Tor%20Browser%20Bundle/Tor%20Browser%20Bundle%20-%20iSEC%20Deliverable%201.3.pdf#16
+user_pref("svg.disabled", true);
+
+
 // PREF: Disable video stats to reduce fingerprinting threat
 // https://bugzilla.mozilla.org/show_bug.cgi?id=654550
 // https://github.com/pyllyukko/user.js/issues/9#issuecomment-100468785

--- a/user.js
+++ b/user.js
@@ -459,13 +459,15 @@ user_pref("browser.selfsupport.url",				"");
 
 // PREF: Disable Firefox Hello metrics collection
 // https://groups.google.com/d/topic/mozilla.dev.platform/nyVkCx-_sFw/discussion
-// TODO: deprecated? not in DXR
 user_pref("loop.logDomains",					false);
 
 // PREF: Enable Auto Update (disabled)
+// NOTICE: Fully automatic updates are disabled and left to package management systems on Linux. Windows users may want to change this setting.
 // CIS 2.1.1
-// This is disabled for now. it is better to patch through package management.
 //user_pref("app.update.auto",					true);
+
+// PREF: Enforce checking for Firefox updates
+user_pref("app.update.enabled",                 true)
 
 // PREF: Enable blocking reported web forgeries
 // https://wiki.mozilla.org/Security/Safe_Browsing

--- a/user.js
+++ b/user.js
@@ -33,6 +33,7 @@ user_pref("dom.webaudio.enabled",				false);
 user_pref("geo.enabled",					false);
 
 // PREF: when geolocation is enabled, use Mozilla geolocation service instead of Google
+// https://bugzilla.mozilla.org/show_bug.cgi?id=689252
 user_pref("geo.wifi.uri", "https://location.services.mozilla.com/v1/geolocate?key=test");
 // PREF: when geolocation is enabled, don't log geolocation requests to the console
 user_pref("geo.wifi.logging.enabled", false);

--- a/user.js
+++ b/user.js
@@ -59,7 +59,7 @@ user_pref("dom.mozTCPSocket.enabled",				false);
 // NOTICE: Disabling DOM storage is known to cause`TypeError: localStorage is null` errors
 //user_pref("dom.storage.enabled",		false);
 
-// PREF: Whether JS can get information about the network/browser connection
+// PREF: Disable leaking network/browser connection information via Javascript
 // Network Information API provides general information about the system's connection type (WiFi, cellular, etc.)
 // https://developer.mozilla.org/en-US/docs/Web/API/Network_Information_API
 // https://wicg.github.io/netinfo/#privacy-considerations
@@ -98,9 +98,13 @@ user_pref("dom.telephony.enabled",				false);
 // https://developer.mozilla.org/en-US/docs/Web/API/navigator.sendBeacon
 user_pref("beacon.enabled",					false);
 
-// PREF: Disable clipboard manipulation via JavaScript
+// PREF: Disable clipboard event detection (onCut/onCopy/onPaste) via Javascript
 // https://developer.mozilla.org/en-US/docs/Mozilla/Preferences/Preference_reference/dom.event.clipboardevents.enabled
 user_pref("dom.event.clipboardevents.enabled",			false);
+
+// PREF: Disable "copy to clipboard" functionality via Javascript (Firefox >= 41)
+// https://hg.mozilla.org/mozilla-central/rev/2f9f8ea4b9c3
+user_pref("dom.allow_cut_copy", false);
 
 // PREF: Disable speech recognition
 // https://dvcs.w3.org/hg/speech-api/raw-file/tip/speechapi.html
@@ -135,8 +139,9 @@ user_pref("browser.send_pings.require_same_host",		true);
 
 // TODO: "Access Your Location" "Maintain Offline Storage" "Show Notifications"
 
-// PREF: Disable gamepad input
+// PREF: Disable gamepad API to prevent USB device enumeration
 // https://www.w3.org/TR/gamepad/
+// https://trac.torproject.org/projects/tor/ticket/13023
 user_pref("dom.gamepad.enabled",				false);
 
 // PREF: Disable virtual reality devices APIs
@@ -272,7 +277,7 @@ user_pref("javascript.options.asmjs",				false);
 // https://github.com/iSECPartners/publications/tree/master/reports/Tor%20Browser%20Bundle
 user_pref("gfx.font_rendering.opentype_svg.enabled",		false);
 
-// PREF: Disable in-content SVG rendering
+// PREF: Disable in-content SVG rendering (Firefox >= 53)
 // NOTICE: Disabling SVG support breaks many UI elements on many sites
 // https://bugzilla.mozilla.org/show_bug.cgi?id=1216893
 // https://github.com/iSECPartners/publications/raw/master/reports/Tor%20Browser%20Bundle/Tor%20Browser%20Bundle%20-%20iSEC%20Deliverable%201.3.pdf#16
@@ -575,8 +580,9 @@ user_pref("network.negotiate-auth.allow-insecure-ntlm-v1",	false);
 // https://bugzilla.mozilla.org/show_bug.cgi?id=855326
 user_pref("security.csp.experimentalEnabled",			true);
 
-// PREF: Enable Content Security Policy
-// CSP https://developer.mozilla.org/en-US/docs/Web/Security/CSP/Introducing_Content_Security_Policy
+// PREF: Enable Content Security Policy (CSP)
+// https://developer.mozilla.org/en-US/docs/Web/Security/CSP/Introducing_Content_Security_Policy
+// https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
 user_pref("security.csp.enable",				true);
 
 // PREF: Enable Subresource Integrity
@@ -809,9 +815,12 @@ user_pref("plugins.update.notifyUser",				true);
 // CIS Version 1.2.0 October 21st, 2011 2.1.3
 user_pref("plugins.hide_infobar_for_outdated_plugin",		false);
 
-// PREF: Enable IDN Show Punycode
+// PREF: Force Punycode for Internationalized Domain Names
 // http://kb.mozillazine.org/Network.IDN_show_punycode
 // https://www.xudongz.com/blog/2017/idn-phishing/
+// https://wiki.mozilla.org/IDN_Display_Algorithm
+// https://en.wikipedia.org/wiki/IDN_homograph_attack
+// https://www.mozilla.org/en-US/security/advisories/mfsa2017-02/
 // CIS Mozilla Firefox 24 ESR v1.0.0 - 3.6
 user_pref("network.IDN_show_punycode",				true);
 

--- a/user.js
+++ b/user.js
@@ -19,7 +19,7 @@ user_pref("dom.serviceWorkers.enabled",				false);
 // PREF: Disable Web Workers
 // https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers
 // https://www.w3schools.com/html/html5_webworkers.asp
-user_pref("dom.workers.enabled",false)
+user_pref("dom.workers.enabled",					false);
 
 // PREF: Disable web notifications
 // https://support.mozilla.org/t5/Firefox/I-can-t-find-Firefox-menu-I-m-trying-to-opt-out-of-Web-Push-and/m-p/1317495#M1006501
@@ -485,7 +485,7 @@ user_pref("loop.logDomains",					false);
 //user_pref("app.update.auto",					true);
 
 // PREF: Enforce checking for Firefox updates
-user_pref("app.update.enabled",                 true)
+user_pref("app.update.enabled",                 true);
 
 // PREF: Enable blocking reported web forgeries
 // https://wiki.mozilla.org/Security/Safe_Browsing

--- a/user.js
+++ b/user.js
@@ -103,6 +103,7 @@ user_pref("beacon.enabled",					false);
 user_pref("dom.event.clipboardevents.enabled",			false);
 
 // PREF: Disable "copy to clipboard" functionality via Javascript (Firefox >= 41)
+// NOTICE: Disabling clipboard operations will break legitimate JS-based "copy to clipboard" functionality
 // https://hg.mozilla.org/mozilla-central/rev/2f9f8ea4b9c3
 user_pref("dom.allow_cut_copy", false);
 
@@ -753,7 +754,7 @@ user_pref("browser.helperApps.deleteTempFileOnExit",		true);
 user_pref("browser.pagethumbnails.capturing_disabled",		true);
 
 // PREF: Don't fetch and permanently store bookmarks favicons to $profile_dir/shortcutCache
-// Use a generic icon instead
+// NOTICE: Bookmarks will only be shown with a generic icon
 user_pref("browser.shell.shortcutFavicons",					false);
 
 // PREF: Disable bookmarks backups (default: 15)

--- a/user.js
+++ b/user.js
@@ -32,10 +32,10 @@ user_pref("dom.webaudio.enabled",				false);
 // https://www.mozilla.org/en-US/firefox/geolocation/
 user_pref("geo.enabled",					false);
 
-// PREF: when geolocation is enabled, use Mozilla geolocation service instead of Google
+// PREF: When geolocation is enabled, use Mozilla geolocation service instead of Google
 // https://bugzilla.mozilla.org/show_bug.cgi?id=689252
 user_pref("geo.wifi.uri", "https://location.services.mozilla.com/v1/geolocate?key=test");
-// PREF: when geolocation is enabled, don't log geolocation requests to the console
+// PREF: When geolocation is enabled, don't log geolocation requests to the console
 user_pref("geo.wifi.logging.enabled", false);
 
 // PREF: Disable raw TCP socket support (mozTCPSocket)

--- a/user.js
+++ b/user.js
@@ -739,6 +739,10 @@ user_pref("browser.helperApps.deleteTempFileOnExit",		true);
 // https://developer.mozilla.org/en-US/docs/Mozilla/Preferences/Preference_reference/browser.pagethumbnails.capturing_disabled
 user_pref("browser.pagethumbnails.capturing_disabled",		true);
 
+// PREF: Don't fetch and permanently store bookmarks favicons to $profile_dir/shortcutCache
+// Use a generic icon instead
+user_pref("browser.shell.shortcutFavicons",					false);
+
 /*******************************************************************************
  * SECTION: UI related                                                         *
  *******************************************************************************/


### PR DESCRIPTION
user.js:
 * fallback on mozilla wifi geolocation services when user re-enables geolocation (instead of Google services)
 * disable geolocation requests logging in console
 * disable more Virtual Reality APIs
 * disable vibrator API
 * when user re-enables URL fixup, still disable it for URLs using 'username:password' syntax
 * enable downloading/using Mozilla SWF blocklists in case some users actually need to re-enable Flash player plugin
 * use master switch browser.selfsupport.enabled to disable Heartbeat, in addition to already empty URL.
 * improve safebrowsing.downloads.enabled description
 * add "Open windows" to default selection in "Clear Private Data" dialog
 * enforce disabling fully automatic password autofill on HTTP sites, even when user re-enables autofill
 * enforce showing an in-content warning for insecure login forms

ignore.list:
 * add browser.safebrowsing.downloads.* fine controls
 * add safebrowsing url prefs
 * explicitely don't set/harden privacy.cpd.passwords/siteSettings and mark it: '(relaxed) ($REASON)' - in this case, reason is better usability - Ref. #231

Thanks to https://github.com/ghacksuserjs/ghacks-user.js/