### PR TITLE
Prevent sites from using external links like mailto.

### DIFF
--- a/user.js
+++ b/user.js
@@ -270,7 +270,7 @@ user_pref("general.buildID.override",				"20100101");
 // https://github.com/pyllyukko/user.js/issues/120
 user_pref("browser.display.use_document_fonts",			0);
 
-// PREF: Prevent sites from using links like mailto to launch external applications.
+// PREF: Prevent sites from using URLs such as mailto:, irc:, magnet:, ... to launch external applications
 // http://kb.mozillazine.org/Network.protocol-handler.external-default
 // http://kb.mozillazine.org/Network.protocol-handler.warn-external-default
 // https://news.ycombinator.com/item?id=13047883

--- a/user.js
+++ b/user.js
@@ -304,7 +304,7 @@ user_pref("network.protocol-handler.warn-external.vnd.youtube", true);
 // http://kb.mozillazine.org/Network.protocol-handler.expose.%28protocol%29
 // NOTICE: Disabling nonessential protocols breaks all interaction with custom protocols such as mailto: irc: magnet: ...
 // TODO: Add more protocols, see TODO for the previous PREF.
-// network.protocol-handler.expose-all == false breaks some javascript links, hence not used.
+// network.protocol-handler.expose-all == false breaks ordinary a href links, hence not used.
 user_pref("network.protocol-handler.expose.irc", 	false);
 user_pref("network.protocol-handler.expose.magnet", 	false);
 user_pref("network.protocol-handler.expose.mailto", 	false);

--- a/user.js
+++ b/user.js
@@ -270,7 +270,7 @@ user_pref("general.buildID.override",				"20100101");
 // https://github.com/pyllyukko/user.js/issues/120
 user_pref("browser.display.use_document_fonts",			0);
 
-// PREF: Prevent sites from using external links like mailto.
+// PREF: Prevent sites from using links like mailto to launch external applications.
 // http://kb.mozillazine.org/Network.protocol-handler.external-default
 // http://kb.mozillazine.org/Network.protocol-handler.warn-external-default
 // https://news.ycombinator.com/item?id=13047883
@@ -279,20 +279,43 @@ user_pref("browser.display.use_document_fonts",			0);
 // TODO: Add externally-handled protocols from Windows 8.1 and Windows 10 (currently contains protocols only from Linux and Windows 7) that might pose a similar threat (see e.g. https://news.ycombinator.com/item?id=13044991)
 // TODO: Add externally-handled protocols from Mac OS X that might pose a similar threat (see e.g. https://news.ycombinator.com/item?id=13044991)
 user_pref("network.protocol-handler.external-default", 		false);
+user_pref("network.protocol-handler.external.irc", 		false);
+user_pref("network.protocol-handler.external.magnet", 		false);
 user_pref("network.protocol-handler.external.mailto", 		false);
 user_pref("network.protocol-handler.external.ms-windows-store", false);
 user_pref("network.protocol-handler.external.news", 		false);
 user_pref("network.protocol-handler.external.nntp", 		false);
+user_pref("network.protocol-handler.external.sftp", 		false);
 user_pref("network.protocol-handler.external.snews", 		false);
 user_pref("network.protocol-handler.warn-external-default", 	true);
+user_pref("network.protocol-handler.warn-external.irc", 	true);
+user_pref("network.protocol-handler.warn-external.magnet", 	true);
 user_pref("network.protocol-handler.warn-external.mailto", 	true);
 user_pref("network.protocol-handler.warn-external.ms-windows-store", true);
 user_pref("network.protocol-handler.warn-external.news", 	true);
 user_pref("network.protocol-handler.warn-external.nntp", 	true);
+user_pref("network.protocol-handler.warn-external.sftp", 	true);
 user_pref("network.protocol-handler.warn-external.sms", 	true);
 user_pref("network.protocol-handler.warn-external.snews", 	true);
 user_pref("network.protocol-handler.warn-external.tel", 	true);
 user_pref("network.protocol-handler.warn-external.vnd.youtube", true);
+
+// PREF: Disable nonessential protocols from being used altogether.
+// http://kb.mozillazine.org/Network.protocol-handler.expose.%28protocol%29
+// NOTICE: Breaks all interactions and links using these protocols.
+// TODO: Add more protocols, see TODO for the previous PREF.
+// network.protocol-handler.expose-all == false breaks some javascript links, hence not used.
+user_pref("network.protocol-handler.expose.irc", 	false);
+user_pref("network.protocol-handler.expose.magnet", 	false);
+user_pref("network.protocol-handler.expose.mailto", 	false);
+user_pref("network.protocol-handler.expose.ms-windows-store", false);
+user_pref("network.protocol-handler.expose.news", 	false);
+user_pref("network.protocol-handler.expose.nntp", 	false);
+user_pref("network.protocol-handler.expose.sftp", 	false);
+user_pref("network.protocol-handler.expose.sms", 	false);
+user_pref("network.protocol-handler.expose.snews", 	false);
+user_pref("network.protocol-handler.expose.tel", 	false);
+user_pref("network.protocol-handler.expose.vnd.youtube", false);
 
 /******************************************************************************
  * SECTION: Extensions / plugins                                                       *

--- a/user.js
+++ b/user.js
@@ -275,7 +275,7 @@ user_pref("browser.display.use_document_fonts",			0);
 // http://kb.mozillazine.org/Network.protocol-handler.warn-external-default
 // https://news.ycombinator.com/item?id=13047883
 // https://bugzilla.mozilla.org/show_bug.cgi?id=167475
-// NOTICE: Breaks mailto links on legit websites, user has to right-click and copy mail address from the link.
+// NOTICE: Disabling external protocol handlers breaks mailto links on legit websites, user has to right-click and copy mail address from the link.
 // TODO: Add externally-handled protocols from Windows 8.1 and Windows 10 (currently contains protocols only from Linux and Windows 7) that might pose a similar threat (see e.g. https://news.ycombinator.com/item?id=13044991)
 // TODO: Add externally-handled protocols from Mac OS X that might pose a similar threat (see e.g. https://news.ycombinator.com/item?id=13044991)
 user_pref("network.protocol-handler.external-default", 		false);
@@ -302,7 +302,7 @@ user_pref("network.protocol-handler.warn-external.vnd.youtube", true);
 
 // PREF: Disable nonessential protocols from being used altogether.
 // http://kb.mozillazine.org/Network.protocol-handler.expose.%28protocol%29
-// NOTICE: Breaks all interactions and links using these protocols.
+// NOTICE: Disabling nonessential protocols (like mailto, magnet, etc.) breaks all interactions and links using these protocols.
 // TODO: Add more protocols, see TODO for the previous PREF.
 // network.protocol-handler.expose-all == false breaks some javascript links, hence not used.
 user_pref("network.protocol-handler.expose.irc", 	false);

--- a/user.js
+++ b/user.js
@@ -270,6 +270,25 @@ user_pref("general.buildID.override",				"20100101");
 // https://github.com/pyllyukko/user.js/issues/120
 user_pref("browser.display.use_document_fonts",			0);
 
+// PREF: Prevent sites from using external links like mailto.
+// https://news.ycombinator.com/item?id=13047883
+// https://bugzilla.mozilla.org/show_bug.cgi?id=167475
+// NOTICE: Breaks mailto links on legit websites, user has to right-click and copy mail address from the link.
+// TODO: Add externally-handled protocols from Windows 8.1 and Windows 10 (currently contains protocols only from Linux and Windows 7) that might pose a similar threat (see e.g. https://news.ycombinator.com/item?id=13044991)
+// TODO: Add externally-handled protocols from Mac OS X that might pose a similar threat (see e.g. https://news.ycombinator.com/item?id=13044991)
+user_pref("network.protocol-handler.external-default", 		false);
+user_pref("network.protocol-handler.external.mailto", 		false);
+user_pref("network.protocol-handler.external.ms-windows-store", false);
+user_pref("network.protocol-handler.external.news", 		false);
+user_pref("network.protocol-handler.external.nntp", 		false);
+user_pref("network.protocol-handler.external.snews", 		false);
+user_pref("network.protocol-handler.warn-external-default", 	true);
+user_pref("network.protocol-handler.warn-external.mailto", 	true);
+user_pref("network.protocol-handler.warn-external.ms-windows-store", true);
+user_pref("network.protocol-handler.warn-external.news", 	true);
+user_pref("network.protocol-handler.warn-external.nntp", 	true);
+user_pref("network.protocol-handler.warn-external.snews", 	true);
+
 /******************************************************************************
  * SECTION: Extensions / plugins                                                       *
  ******************************************************************************/

--- a/user.js
+++ b/user.js
@@ -273,11 +273,14 @@ user_pref("browser.display.use_document_fonts",			0);
 // PREF: Prevent sites from using URLs such as mailto:, irc:, magnet:, ... to launch external applications
 // http://kb.mozillazine.org/Network.protocol-handler.external-default
 // http://kb.mozillazine.org/Network.protocol-handler.warn-external-default
+// http://kb.mozillazine.org/Network.protocol-handler.expose.%28protocol%29
 // https://news.ycombinator.com/item?id=13047883
 // https://bugzilla.mozilla.org/show_bug.cgi?id=167475
-// NOTICE: Disabling external protocol handlers breaks opening third-party mail/messaging/torrent/... clients by cliking on links with custom protocols
+// https://github.com/pyllyukko/user.js/pull/285#issuecomment-298124005
+// NOTICE: Disabling nonessential protocols breaks all interaction with custom protocols such as mailto:, irc:, magnet: ... and breaks opening third-party mail/messaging/torrent/... clients when clicking on links with these protocols
 // TODO: Add externally-handled protocols from Windows 8.1 and Windows 10 (currently contains protocols only from Linux and Windows 7) that might pose a similar threat (see e.g. https://news.ycombinator.com/item?id=13044991)
 // TODO: Add externally-handled protocols from Mac OS X that might pose a similar threat (see e.g. https://news.ycombinator.com/item?id=13044991)
+// If you want to enable a protocol, delete all three preferences for the protocol (external.protocolname, warn-external.protocolname, expose.protocolname).
 user_pref("network.protocol-handler.external-default", 		false);
 user_pref("network.protocol-handler.external.irc", 		false);
 user_pref("network.protocol-handler.external.magnet", 		false);
@@ -299,23 +302,18 @@ user_pref("network.protocol-handler.warn-external.sms", 	true);
 user_pref("network.protocol-handler.warn-external.snews", 	true);
 user_pref("network.protocol-handler.warn-external.tel", 	true);
 user_pref("network.protocol-handler.warn-external.vnd.youtube", true);
-
-// PREF: Disable nonessential protocols from being used altogether.
-// http://kb.mozillazine.org/Network.protocol-handler.expose.%28protocol%29
-// NOTICE: Disabling nonessential protocols breaks all interaction with custom protocols such as mailto: irc: magnet: ...
-// TODO: Add more protocols, see TODO for the previous PREF.
-// network.protocol-handler.expose-all == false breaks ordinary a href links, hence not used.
-user_pref("network.protocol-handler.expose.irc", 	false);
-user_pref("network.protocol-handler.expose.magnet", 	false);
-user_pref("network.protocol-handler.expose.mailto", 	false);
-user_pref("network.protocol-handler.expose.ms-windows-store", false);
-user_pref("network.protocol-handler.expose.news", 	false);
-user_pref("network.protocol-handler.expose.nntp", 	false);
-user_pref("network.protocol-handler.expose.sftp", 	false);
-user_pref("network.protocol-handler.expose.sms", 	false);
-user_pref("network.protocol-handler.expose.snews", 	false);
-user_pref("network.protocol-handler.expose.tel", 	false);
-user_pref("network.protocol-handler.expose.vnd.youtube", false);
+// network.protocol-handler.expose-all == false breaks ordinary http, https links, hence not used.
+user_pref("network.protocol-handler.expose.irc", 		false);
+user_pref("network.protocol-handler.expose.magnet", 		false);
+user_pref("network.protocol-handler.expose.mailto", 		false);
+user_pref("network.protocol-handler.expose.ms-windows-store", 	false);
+user_pref("network.protocol-handler.expose.news", 		false);
+user_pref("network.protocol-handler.expose.nntp", 		false);
+user_pref("network.protocol-handler.expose.sftp", 		false);
+user_pref("network.protocol-handler.expose.sms", 		false);
+user_pref("network.protocol-handler.expose.snews", 		false);
+user_pref("network.protocol-handler.expose.tel", 		false);
+user_pref("network.protocol-handler.expose.vnd.youtube", 	false);
 
 /******************************************************************************
  * SECTION: Extensions / plugins                                                       *

--- a/user.js
+++ b/user.js
@@ -275,7 +275,7 @@ user_pref("browser.display.use_document_fonts",			0);
 // http://kb.mozillazine.org/Network.protocol-handler.warn-external-default
 // https://news.ycombinator.com/item?id=13047883
 // https://bugzilla.mozilla.org/show_bug.cgi?id=167475
-// NOTICE: Disabling external protocol handlers breaks mailto links on legit websites, user has to right-click and copy mail address from the link.
+// NOTICE: Disabling external protocol handlers breaks opening third-party mail/messaging/torrent/... clients by cliking on links with custom protocols
 // TODO: Add externally-handled protocols from Windows 8.1 and Windows 10 (currently contains protocols only from Linux and Windows 7) that might pose a similar threat (see e.g. https://news.ycombinator.com/item?id=13044991)
 // TODO: Add externally-handled protocols from Mac OS X that might pose a similar threat (see e.g. https://news.ycombinator.com/item?id=13044991)
 user_pref("network.protocol-handler.external-default", 		false);
@@ -302,7 +302,7 @@ user_pref("network.protocol-handler.warn-external.vnd.youtube", true);
 
 // PREF: Disable nonessential protocols from being used altogether.
 // http://kb.mozillazine.org/Network.protocol-handler.expose.%28protocol%29
-// NOTICE: Disabling nonessential protocols (like mailto, magnet, etc.) breaks all interactions and links using these protocols.
+// NOTICE: Disabling nonessential protocols breaks all interaction with custom protocols such as mailto: irc: magnet: ...
 // TODO: Add more protocols, see TODO for the previous PREF.
 // network.protocol-handler.expose-all == false breaks some javascript links, hence not used.
 user_pref("network.protocol-handler.expose.irc", 	false);

--- a/user.js
+++ b/user.js
@@ -271,6 +271,8 @@ user_pref("general.buildID.override",				"20100101");
 user_pref("browser.display.use_document_fonts",			0);
 
 // PREF: Prevent sites from using external links like mailto.
+// http://kb.mozillazine.org/Network.protocol-handler.external-default
+// http://kb.mozillazine.org/Network.protocol-handler.warn-external-default
 // https://news.ycombinator.com/item?id=13047883
 // https://bugzilla.mozilla.org/show_bug.cgi?id=167475
 // NOTICE: Breaks mailto links on legit websites, user has to right-click and copy mail address from the link.
@@ -287,7 +289,10 @@ user_pref("network.protocol-handler.warn-external.mailto", 	true);
 user_pref("network.protocol-handler.warn-external.ms-windows-store", true);
 user_pref("network.protocol-handler.warn-external.news", 	true);
 user_pref("network.protocol-handler.warn-external.nntp", 	true);
+user_pref("network.protocol-handler.warn-external.sms", 	true);
 user_pref("network.protocol-handler.warn-external.snews", 	true);
+user_pref("network.protocol-handler.warn-external.tel", 	true);
+user_pref("network.protocol-handler.warn-external.vnd.youtube", true);
 
 /******************************************************************************
  * SECTION: Extensions / plugins                                                       *


### PR DESCRIPTION
- Disable protocols like mailto from being handled by external applications, so that evil trap sites can't launch external applications.