### PR TITLE
[master] add NOTICE for browser.display.use_document_fonts

### DIFF
--- a/user.js
+++ b/user.js
@@ -306,7 +306,8 @@ user_pref("media.video_stats.enabled",				false);
 // https://bugzilla.mozilla.org/show_bug.cgi?id=583181
 user_pref("general.buildID.override",				"20100101");
 
-// PREF: Prevent font fingerprinting
+// PREF: Don't let websites specify which fonts to use to prevent font fingerprinting
+// NOTICE: Disabling document fonts breaks functionality websites using custom icon fonts
 // https://browserleaks.com/fonts
 // https://github.com/pyllyukko/user.js/issues/120
 user_pref("browser.display.use_document_fonts",			0);


### PR DESCRIPTION
Aside from the minor inconvenience of having all pages display with default Serif/Sans Serif fonts (you get used to it), `browser.display.use_document_fonts = false` breaks functionality on websites using icon fonts (such as [font awesome](http://fontawesome.io/)) to display UI elements/buttons/symbols/...

This is one of the main complaints I've heard from `user.js` users IRL/online. I have disabled this myself. A a _lot_ of websites make heavy use of icon fonts, sometimes there's an `alt` text or other indication that this or that is the button you are looking for, but most often not. As it's only used to prevent fingerprinting I suggest that it can be disabled in https://github.com/pyllyukko/user.js/tree/relaxed. Should I send another patch?