### PR TITLE
disable Shumway (Mozilla Flash renderer)

### DIFF
--- a/user.js
+++ b/user.js
@@ -377,6 +377,10 @@ user_pref("dom.ipc.plugins.reportCrashURL",			false);
 // https://github.com/mozilla-services/shavar-plugin-blocklist
 user_pref("browser.safebrowsing.blockedURIs.enabled", true);
 
+// PREF: Disable Shumway (Mozilla Flash renderer)
+// https://developer.mozilla.org/en-US/docs/Mozilla/Projects/Shumway
+pref("shumway.disabled", true);
+
 // PREF: Disable Gnome Shell Integration
 user_pref("plugin.state.libgnome-shell-browser-plugin",		0);
 


### PR DESCRIPTION
No known security implications, disabling as general precaution.
Shumway code can be found here https://github.com/mozilla/shumway