### PR TITLE
[relaxed] do not enforce Mixed Passive Content blocking

### DIFF
--- a/user.js
+++ b/user.js
@@ -254,9 +254,9 @@ user_pref("network.manage-offline-status",			false);
 // https://blog.mozilla.org/tanvi/2013/04/10/mixed-content-blocking-enabled-in-firefox-23/
 user_pref("security.mixed_content.block_active_content",	true);
 
-// PREF: Enforce Mixed Passive Content blocking (a.k.a. Mixed Display Content)
+// PREF: Enforce Mixed Passive Content blocking (a.k.a. Mixed Display Content) (disabled)
 // NOTICE: Enabling Mixed Display Content blocking can prevent images/styles... from loading properly when connection to the website is only partially secured
-user_pref("security.mixed_content.block_display_content",	true);
+// user_pref("security.mixed_content.block_display_content",	true);
 
 // PREF: Disable JAR from opening Unsafe File Types
 // http://kb.mozillazine.org/Network.jar.open-unsafe-types


### PR DESCRIPTION
as mixed passive content is very frequently encountered, and is silently blocked (there is no indication of what happens, some page elements just do not display). See missing images on https://forum.freecadweb.org/viewtopic.php?f=24&t=22922 for example. This is still mitigated by either using uBlock in Hard mode, or by setting HTTPS everywhere to `Block all unencrypted requests`.