### PR TITLE
Fix (intentional?) directory name, add mozilla.cfg bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,13 @@ This file should be located at:
 
 | OS      | Path                                                         |
 | ------- | ------------------------------------------------------------ |
-| Windows | `C:\Program Files (x86)\Mozilla Firefox\default\pref\`       |
+| Windows | `C:\Program Files (x86)\Mozilla Firefox\defaults\pref\`      |
 | OS X    | `/Applications/Firefox.app/Contents/Resources/defaults/pref` |
+
+If mozilla.cfg still fails to load, you must add a blank comment to the top of mozilla.cg like so:
+```
+//
+```
 
 ### Updating using git
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ This file should be located at:
 | Windows | `C:\Program Files (x86)\Mozilla Firefox\defaults\pref\`      |
 | OS X    | `/Applications/Firefox.app/Contents/Resources/defaults/pref` |
 
-If mozilla.cfg still fails to load, you must add a blank comment to the top of mozilla.cg like so:
+If mozilla.cfg still fails to load, you must add a blank comment to the top of mozilla.cfg like so:
 ```
 //
 ```


### PR DESCRIPTION
The mozilla.cfg fix is what fixed the failing to load issue on my install Firefox 54, 64-bit, WIndows 10. Also the folder is "defaults" on my install, not "default".