### PR TITLE
ignore general.useragent.locale

### DIFF
--- a/ignore.list
+++ b/ignore.list
@@ -496,3 +496,10 @@
 // https://hg.mozilla.org/mozilla-central/rev/206139
 "plugins.hideMissingPluginsNotification"
 "plugins.notifyMissingFlash"
+
+// PREF: Set Firefox locale to en-US
+// http://kb.mozillazine.org/General.useragent.locale
+// window.navigator.language is now determined by intl.accept_languages
+// https://bugzilla.mozilla.org/show_bug.cgi?id=448743
+"general.useragent.locale"
+

--- a/user.js
+++ b/user.js
@@ -210,10 +210,6 @@ user_pref("browser.search.geoip.url",				"");
 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language
 user_pref("intl.accept_languages",				"en-us, en");
 
-// PREF: Set Firefox locale to en-US
-// http://kb.mozillazine.org/General.useragent.locale
-user_pref("general.useragent.locale",				"en-US");
-
 // PREF: Don't use OS values to determine locale, force using Firefox locale setting
 // http://kb.mozillazine.org/Intl.locale.matchOS
 user_pref("intl.locale.matchOS",				false);


### PR DESCRIPTION
window.navigator.language (accessible via JS) is now determined by the value of intl.accept_languages
https://bugzilla.mozilla.org/show_bug.cgi?id=448743
general.useragent.locale is now (only?) used to set the Firefox UI locale