### PR TITLE
Revert intl.accept_languages to "en-US, us"

### DIFF
--- a/user.js
+++ b/user.js
@@ -218,7 +218,7 @@ user_pref("browser.search.geoip.url",				"");
 
 // PREF: Set Accept-Language HTTP header to en-US regardless of Firefox localization
 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language
-user_pref("intl.accept_languages",				"en-us, en");
+user_pref("intl.accept_languages",				"en-US, en");
 
 // PREF: Don't use OS values to determine locale, force using Firefox locale setting
 // http://kb.mozillazine.org/Intl.locale.matchOS


### PR DESCRIPTION
Reverts https://github.com/pyllyukko/user.js/pull/253

The bug reported at https://bugzilla.mozilla.org/show_bug.cgi?id=1349302 and https://github.com/pyllyukko/user.js/issues/252 was somehow reintroduced, but the other way around (a lowercase value now triggers it, the old value fixes the problem).

I'll report the new behavior on bugzilla, in the mean time let's just revert it?

Edit: I am not sure about the purpose of forcing accept-languages to en-US. There is no information about it in comments. Is it an anti-fingerprinting measure? If so one can argue that en-US would be an unusual value in most countries. It makes sense from the TBB perspective but probably not here. Move it to ignore.list with this reasoning in comments?