### PR TITLE
Revert "Added notice for first-party isolation"

### DIFF
--- a/user.js
+++ b/user.js
@@ -702,7 +702,6 @@ user_pref("network.cookie.cookieBehavior",			1);
 // https://bugzilla.mozilla.org/show_bug.cgi?id=1299996
 // https://bugzilla.mozilla.org/show_bug.cgi?id=1260931
 // https://wiki.mozilla.org/Security/FirstPartyIsolation
-// NOTICE: Breaks Firefox addon "Cookie AutoDelete" as of February 2018
 user_pref("privacy.firstparty.isolate",				true);
 
 // PREF: Make sure that third-party cookies (if enabled) never persist beyond the session.


### PR DESCRIPTION
Firefox 59 is out and the issue is fixed. Removed the notification to reduce the clutter.
https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/issues/75