### PR TITLE
README: add link to Firefox policy templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,6 +564,7 @@ For more information, see [CONTRIBUTING](https://github.com/pyllyukko/user.js/bl
 * [Polaris - advance privacy technnology for the web](https://wiki.mozilla.org/Polaris)
 * [Mozilla Privacy Principles](https://wiki.mozilla.org/Privacy/Principles)
 * [List of Firefox "about:" URLs](https://developer.mozilla.org/en-US/Firefox/The_about_protocol)
+* [Policy Templates for Firefox](https://github.com/mozilla/policy-templates)
 * [Mozilla preferences for uber-geeks](https://developer.mozilla.org/en-US/docs/Mozilla/Preferences/Mozilla_preferences_for_uber-geeks)
 * [Privacy & Security related add-ons](https://addons.mozilla.org/firefox/extensions/privacy-security/) ([RSS](https://addons.mozilla.org/en-US/firefox/extensions/privacy-security/format:rss?sort=featured))
 


### PR DESCRIPTION
Following the release of Firefox 60, policies can be applied to Firefox for enterprise deployments,
either through Group Policy for Windows systems, or a .json file on MacOS and Linux.
https://support.mozilla.org/en-US/products/firefox-enterprise/policies-enterprise
https://support.mozilla.org/en-US/kb/customizing-firefox-using-policiesjson