### PR TITLE
update notice about dom.workers.enabled

### DIFF
--- a/user.js
+++ b/user.js
@@ -20,7 +20,7 @@ user_pref("dom.serviceWorkers.enabled",				false);
 // PREF: Disable Web Workers
 // https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers
 // https://www.w3schools.com/html/html5_webworkers.asp
-// NOTICE: Disabling Web Workers breaks "Download as ZIP" functionality on https://mega.nz/, WhatsApp Web and probably others
+// NOTICE: Disabling Web Workers breaks "Download as ZIP" functionality on https://mega.nz/, WhatsApp Web, upload on https://www.virustotal.com/,  and probably others
 user_pref("dom.workers.enabled",					false);
 
 // PREF: Disable web notifications


### PR DESCRIPTION
Website works again after setting this pref to `true`.

Edit: additionally found these resources about web workers security:
- https://www.mozilla.org/en-US/security/advisories/mfsa2010-02/ 2010 bug
- https://w3c.github.io/workers/#security-considerations 
- https://www.owasp.org/index.php/HTML5_Security_Cheat_Sheet#Web_Workers
- https://stackoverflow.com/questions/12791699/do-web-workers-increase-or-decrease-security
- https://jcarlosnorte.com/security/2016/03/06/advanced-tor-browser-fingerprinting.html

So far the concerns about Web Workers seem to relate to:
 - Increased attack surface (though I could not find a recent known vulnerability)
 - Possibility of DoSing the browser through heavy computation
 - Possibility of XSS when improperly implemented by websites
 - Possible mouse movement/CPU performance fingerprinting, tracked at https://trac.torproject.org/projects/tor/ticket/17023

Please let me know if some of these links should be included in the patch