### PR TITLE
Turn off Trusted Recursive Resolver (avoid Cloudflare DNS queries)

### DIFF
--- a/user.js
+++ b/user.js
@@ -445,9 +445,9 @@ user_pref("extensions.systemAddon.update.enabled",		false);
 // https://support.mozilla.org/en-US/kb/extension-recommendations
 user_pref("browser.newtabpage.activity-stream.asrouter.userprefs.cfr",	false);
 
-// PREF: Trusted Recursive Resolver (DNS-over-HTTPS) (disabled)
+// PREF: Trusted Recursive Resolver (DNS-over-HTTPS) (disabled, avoid cloudflare DNS queries)
 // https://wiki.mozilla.org/Trusted_Recursive_Resolver
-//user_pref("network.trr.mode",					0);
+user_pref("network.trr.mode",					5);
 
 // PREF: Disable WebIDE
 // https://trac.torproject.org/projects/tor/ticket/16222


### PR DESCRIPTION
Explicitly Turn Off Trusted Recursive Resolver (DNS over HTTPS): 

https://wiki.mozilla.org/Trusted_Recursive_Resolver

Set `network.trr.mode` to 2 to make DNS Over HTTPS the browser's first choice but use regular DNS as a fallback (0 is "off by default", 1 lets Firefox pick whichever is faster, 3 for TRR only mode, 5 to explicitly turn it off).
 
`user_pref("network.trr.mode", 5);`

https://github.com/pyllyukko/user.js/compare/master...brainfucksec:patch-1?expand=1#diff-b00df6cb4137c00991376cd319d35348

in this way the browser uses the DNS set in the system.

