### PR TITLE
shellcheck: ignore check SC1117: Backslash is literal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ bash_syntax:
 .PHONY: shellcheck
 shellcheck:
     ######## check/lint all shell scripts
-	shellcheck *.sh
+	shellcheck --exclude=SC1117 *.sh
 
 
 ##### MAINTENANCE #####


### PR DESCRIPTION
- https://github.com/koalaman/shellcheck/wiki/SC1117
- SC1117: Backslash is literal in "\:". Prefer explicit escaping: "\\:".
- Ref. https://github.com/pyllyukko/user.js/issues/492