### PR TITLE
Trim HTTP referers

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,8 @@ HTTP protocol related entries. This affects cookies, the user agent, referer and
 * Enable Content Security Policy (CSP) [ [1](https://developer.mozilla.org/en-US/docs/Web/Security/CSP/Introducing_Content_Security_Policy) [2](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) ]
 * Enable Subresource Integrity [ [1](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) [2](https://wiki.mozilla.org/Security/Subresource_Integrity) ]
 * Don't send referer headers when following links across different domains [ [1](https://github.com/pyllyukko/user.js/issues/227) [2](https://github.com/pyllyukko/user.js/issues/328) [3](https://feeding.cloud.geek.nz/posts/tweaking-referrer-for-privacy-in-firefox/) ]
+* Trim HTTP referer headers to only send the scheme, host, and port [ [1](https://wiki.mozilla.org/Privacy/Privacy_Task_Force/firefox_about_config_privacy_tweeks) ]
+* When sending Referer across domains, only send scheme, host, and port in the Referer header [ [1](https://wiki.mozilla.org/Privacy/Privacy_Task_Force/firefox_about_config_privacy_tweeks) ]
 * Accept Only 1st Party Cookies [ [1](http://kb.mozillazine.org/Network.cookie.cookieBehavior#1) ]
 * Enable first-party isolation [ [1](https://bugzilla.mozilla.org/show_bug.cgi?id=1299996) [2](https://bugzilla.mozilla.org/show_bug.cgi?id=1260931) [3](https://wiki.mozilla.org/Security/FirstPartyIsolation) ]
 * Make sure that third-party cookies (if enabled) never persist beyond the session. [ [1](https://feeding.cloud.geek.nz/posts/tweaking-cookies-for-privacy-in-firefox/) [2](http://kb.mozillazine.org/Network.cookie.thirdparty.sessionOnly) [3](https://developer.mozilla.org/en-US/docs/Cookies_Preferences_in_Mozilla#network.cookie.thirdparty.sessionOnly) ]

--- a/user.js
+++ b/user.js
@@ -761,6 +761,14 @@ user_pref("security.sri.enable",				true);
 // https://feeding.cloud.geek.nz/posts/tweaking-referrer-for-privacy-in-firefox/
 user_pref("network.http.referer.XOriginPolicy",		2);
 
+// PREF: Trim HTTP referer headers to only send the scheme, host, and port
+// https://wiki.mozilla.org/Privacy/Privacy_Task_Force/firefox_about_config_privacy_tweeks
+user_pref("network.http.referer.trimmingPolicy",	2);
+
+// PREF: When sending Referer across domains, only send scheme, host, and port in the Referer header
+// https://wiki.mozilla.org/Privacy/Privacy_Task_Force/firefox_about_config_privacy_tweeks
+user_pref("network.http.referer.XOriginTrimmingPolicy",	2);
+
 // PREF: Accept Only 1st Party Cookies
 // http://kb.mozillazine.org/Network.cookie.cookieBehavior#1
 // NOTICE: Blocking 3rd-party cookies breaks a number of payment gateways


### PR DESCRIPTION
- fixes https://github.com/pyllyukko/user.js/issues/550

Same warning as for https://github.com/pyllyukko/user.js/pull/553, altering referers is a frequent cause for breakage on sites that rely on them (I didn't include the notice because it is already present twice in prefs above).

For a relaxed variant I recommend first relaxing `network.http.referer.trimmingPolicy` to 1 then 0 (because `network.http.referer.XOriginTrimmingPolicy` still protects against sending full referers across origins), and in last resort relaxing `network.http.referer.XOriginTrimmingPolicy`.

Again, these prefs *will* break websites, but the notice is present.